### PR TITLE
[Codex] Extract top menu and add File menu

### DIFF
--- a/WordForge/MainWindow.xaml
+++ b/WordForge/MainWindow.xaml
@@ -1,6 +1,7 @@
-﻿<Window x:Class="WordForge.MainWindow"
+<Window x:Class="WordForge.MainWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:topmenu="clr-namespace:WordForge.Menus.TopMenu;assembly=WordForge"
         Title="WordForge - New Project" Height="800" Width="1280"
         WindowStartupLocation="CenterScreen"
         Background="#FF1A1B1E"
@@ -17,71 +18,7 @@
         </Grid.RowDefinitions>
 
         <!-- ===== TOP BAR ===== -->
-        <Border Grid.Row="0" Background="#FF2A2D31" BorderBrush="#FF0F1012" BorderThickness="0,0,0,1">
-            <Grid Margin="12,12,12,10">
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="40"/>
-                    <!-- Hamburger -->
-                    <ColumnDefinition Width="16"/>
-                    <ColumnDefinition Width="140"/>
-                    <!-- Title 'Right Pane' -->
-                    <ColumnDefinition Width="16"/>
-                    <ColumnDefinition Width="120"/>
-                    <!-- Timeline -->
-                    <ColumnDefinition Width="12"/>
-                    <ColumnDefinition Width="120"/>
-                    <!-- Outline -->
-                    <ColumnDefinition Width="18"/>
-                    <ColumnDefinition Width="210"/>
-                    <!-- Bibles group -->
-                    <ColumnDefinition Width="*"/>
-                </Grid.ColumnDefinitions>
-
-                <!-- Hamburger -->
-                <Border Grid.Column="0" Background="#FF232529" BorderBrush="#FF3B3F45" BorderThickness="1" CornerRadius="4"
-                        ToolTip="Menu" Cursor="Hand">
-                    <StackPanel VerticalAlignment="Center" Margin="8,6">
-                        <Rectangle Height="3" Fill="#FFE5E7EB" Margin="0,2"/>
-                        <Rectangle Height="3" Fill="#FFE5E7EB" Margin="0,2"/>
-                        <Rectangle Height="3" Fill="#FFE5E7EB" Margin="0,2"/>
-                    </StackPanel>
-                </Border>
-
-                <!-- Right Pane label -->
-                <TextBlock Grid.Column="2" Text="Right Pane" Foreground="#FFE5E7EB" FontWeight="Bold" VerticalAlignment="Center" />
-
-                <!-- Timeline button -->
-                <Button Grid.Column="4" Height="52" Background="#FFE5E7EB" BorderBrush="#FF9CA3AF"
-                        Foreground="#FF111111" FontWeight="Bold" Cursor="Hand" Content="Timeline"/>
-
-                <!-- Outline button -->
-                <Button Grid.Column="6" Height="52" Background="#FFE5E7EB" BorderBrush="#FF9CA3AF"
-                        Foreground="#FF111111" FontWeight="Bold" Cursor="Hand" Content="Outline"/>
-
-                <!-- Bibles group -->
-                <Border Grid.Column="8" Background="#FF232529" BorderBrush="#FF3B3F45" BorderThickness="1" CornerRadius="6" Padding="10">
-                    <Grid>
-                        <Grid.RowDefinitions>
-                            <RowDefinition Height="Auto"/>
-                            <RowDefinition Height="8"/>
-                            <RowDefinition Height="*"/>
-                        </Grid.RowDefinitions>
-                        <TextBlock Text="Bibles" Foreground="#FFE5E7EB" FontWeight="Bold"/>
-                        <StackPanel Grid.Row="2" Orientation="Horizontal" HorizontalAlignment="Left" >
-                            <Button Width="90" Height="36" Margin="0,0,8,0"
-                                    Background="#FFE5E7EB" BorderBrush="#FF9CA3AF"
-                                    Foreground="#FF111111" FontWeight="SemiBold" Content="Character"/>
-                            <Button Width="90" Height="36" Margin="0,0,8,0"
-                                    Background="#FFE5E7EB" BorderBrush="#FF9CA3AF"
-                                    Foreground="#FF111111" FontWeight="SemiBold" Content="Location"/>
-                            <Button Width="90" Height="36"
-                                    Background="#FFE5E7EB" BorderBrush="#FF9CA3AF"
-                                    Foreground="#FF111111" FontWeight="SemiBold" Content="Item"/>
-                        </StackPanel>
-                    </Grid>
-                </Border>
-            </Grid>
-        </Border>
+        <topmenu:TranscriptMenu Grid.Row="0"/>
 
         <!-- ===== MAIN AREA (left rail + center + right pane ~25%) ===== -->
         <Grid Grid.Row="1">

--- a/WordForge/menus/FileMenu.xaml
+++ b/WordForge/menus/FileMenu.xaml
@@ -1,0 +1,19 @@
+<UserControl x:Class="WordForge.Menus.FileMenu"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <Border Background="#FF232529" BorderBrush="#FF3B3F45" BorderThickness="1" CornerRadius="4" Padding="10">
+        <StackPanel>
+            <Button Content="New" Margin="0,0,0,4" Background="#FFE5E7EB" BorderBrush="#FF9CA3AF" Foreground="#FF111111" />
+            <!-- TODO: Wire up New -->
+            <Button Content="Save" Margin="0,0,0,4" Background="#FFE5E7EB" BorderBrush="#FF9CA3AF" Foreground="#FF111111" />
+            <!-- TODO: Wire up Save -->
+            <Button Content="Load" Margin="0,0,0,4" Background="#FFE5E7EB" BorderBrush="#FF9CA3AF" Foreground="#FF111111" />
+            <!-- TODO: Wire up Load -->
+            <Button Content="Properties" Margin="0,0,0,4" Background="#FFE5E7EB" BorderBrush="#FF9CA3AF" Foreground="#FF111111" />
+            <!-- TODO: Wire up Properties -->
+            <Button Content="Print" Margin="0,0,0,4" Background="#FFE5E7EB" BorderBrush="#FF9CA3AF" Foreground="#FF111111" />
+            <!-- TODO: Wire up Print -->
+            <Button Content="Exit" Background="#FFE5E7EB" BorderBrush="#FF9CA3AF" Foreground="#FF111111" Click="Exit_Click" />
+        </StackPanel>
+    </Border>
+</UserControl>

--- a/WordForge/menus/FileMenu.xaml.cs
+++ b/WordForge/menus/FileMenu.xaml.cs
@@ -1,0 +1,17 @@
+using System.Windows;
+using System.Windows.Controls;
+
+namespace WordForge.Menus;
+
+public partial class FileMenu : UserControl
+{
+    public FileMenu()
+    {
+        InitializeComponent();
+    }
+
+    private void Exit_Click(object sender, RoutedEventArgs e)
+    {
+        Application.Current.Shutdown();
+    }
+}

--- a/WordForge/menus/topmenu/TranscriptMenu.xaml
+++ b/WordForge/menus/topmenu/TranscriptMenu.xaml
@@ -1,0 +1,76 @@
+<UserControl x:Class="WordForge.Menus.TopMenu.TranscriptMenu"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:menus="clr-namespace:WordForge.Menus">
+    <Border Background="#FF2A2D31" BorderBrush="#FF0F1012" BorderThickness="0,0,0,1">
+        <Grid Margin="12,12,12,10">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="40"/>
+                <!-- Hamburger -->
+                <ColumnDefinition Width="16"/>
+                <ColumnDefinition Width="140"/>
+                <!-- Title 'Right Pane' -->
+                <ColumnDefinition Width="16"/>
+                <ColumnDefinition Width="120"/>
+                <!-- Timeline -->
+                <ColumnDefinition Width="12"/>
+                <ColumnDefinition Width="120"/>
+                <!-- Outline -->
+                <ColumnDefinition Width="18"/>
+                <ColumnDefinition Width="210"/>
+                <!-- Bibles group -->
+                <ColumnDefinition Width="*"/>
+            </Grid.ColumnDefinitions>
+
+            <!-- Hamburger -->
+            <Border Grid.Column="0" Background="#FF232529" BorderBrush="#FF3B3F45" BorderThickness="1" CornerRadius="4">
+                <Button x:Name="HamburgerButton" Background="Transparent" BorderThickness="0"
+                        ToolTip="Menu" Cursor="Hand">
+                    <StackPanel VerticalAlignment="Center" Margin="8,6">
+                        <Rectangle Height="3" Fill="#FFE5E7EB" Margin="0,2"/>
+                        <Rectangle Height="3" Fill="#FFE5E7EB" Margin="0,2"/>
+                        <Rectangle Height="3" Fill="#FFE5E7EB" Margin="0,2"/>
+                    </StackPanel>
+                </Button>
+            </Border>
+
+            <Popup x:Name="HamburgerPopup" PlacementTarget="{Binding ElementName=HamburgerButton}" StaysOpen="False">
+                <menus:FileMenu />
+            </Popup>
+
+            <!-- Right Pane label -->
+            <TextBlock Grid.Column="2" Text="Right Pane" Foreground="#FFE5E7EB" FontWeight="Bold" VerticalAlignment="Center"/>
+
+            <!-- Timeline button -->
+            <Button Grid.Column="4" Height="52" Background="#FFE5E7EB" BorderBrush="#FF9CA3AF"
+                    Foreground="#FF111111" FontWeight="Bold" Cursor="Hand" Content="Timeline"/>
+
+            <!-- Outline button -->
+            <Button Grid.Column="6" Height="52" Background="#FFE5E7EB" BorderBrush="#FF9CA3AF"
+                    Foreground="#FF111111" FontWeight="Bold" Cursor="Hand" Content="Outline"/>
+
+            <!-- Bibles group -->
+            <Border Grid.Column="8" Background="#FF232529" BorderBrush="#FF3B3F45" BorderThickness="1" CornerRadius="6" Padding="10">
+                <Grid>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="8"/>
+                        <RowDefinition Height="*"/>
+                    </Grid.RowDefinitions>
+                    <TextBlock Text="Bibles" Foreground="#FFE5E7EB" FontWeight="Bold"/>
+                    <StackPanel Grid.Row="2" Orientation="Horizontal" HorizontalAlignment="Left">
+                        <Button Width="90" Height="36" Margin="0,0,8,0"
+                                Background="#FFE5E7EB" BorderBrush="#FF9CA3AF"
+                                Foreground="#FF111111" FontWeight="SemiBold" Content="Character"/>
+                        <Button Width="90" Height="36" Margin="0,0,8,0"
+                                Background="#FFE5E7EB" BorderBrush="#FF9CA3AF"
+                                Foreground="#FF111111" FontWeight="SemiBold" Content="Location"/>
+                        <Button Width="90" Height="36"
+                                Background="#FFE5E7EB" BorderBrush="#FF9CA3AF"
+                                Foreground="#FF111111" FontWeight="SemiBold" Content="Item"/>
+                    </StackPanel>
+                </Grid>
+            </Border>
+        </Grid>
+    </Border>
+</UserControl>

--- a/WordForge/menus/topmenu/TranscriptMenu.xaml.cs
+++ b/WordForge/menus/topmenu/TranscriptMenu.xaml.cs
@@ -1,0 +1,18 @@
+using System.Windows;
+using System.Windows.Controls;
+
+namespace WordForge.Menus.TopMenu;
+
+public partial class TranscriptMenu : UserControl
+{
+    public TranscriptMenu()
+    {
+        InitializeComponent();
+        HamburgerButton.Click += HamburgerButton_Click;
+    }
+
+    private void HamburgerButton_Click(object sender, RoutedEventArgs e)
+    {
+        HamburgerPopup.IsOpen = !HamburgerPopup.IsOpen;
+    }
+}


### PR DESCRIPTION
## Summary
- Move the existing top bar into a reusable `TranscriptMenu` control with a hamburger trigger and popup file menu.
- Add a `FileMenu` control containing file actions and wire the Exit action to shut down the app.
- Replace the top bar in `MainWindow` with the new `TranscriptMenu` control.
- Fix namespace reference and replace unsupported `CornerRadius` usage to resolve build errors.

## Testing
- `dotnet build` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68a4f116a4a08330963311c795b6541f