### PR TITLE
Fix TranscriptMenu CornerRadius usage

### DIFF
--- a/WordForge/menus/topmenu/TranscriptMenu.xaml
+++ b/WordForge/menus/topmenu/TranscriptMenu.xaml
@@ -23,14 +23,15 @@
             </Grid.ColumnDefinitions>
 
             <!-- Hamburger -->
-            <Button x:Name="HamburgerButton" Grid.Column="0" Background="#FF232529" BorderBrush="#FF3B3F45" BorderThickness="1" CornerRadius="4"
-                    ToolTip="Menu" Cursor="Hand">
-                <StackPanel VerticalAlignment="Center" Margin="8,6">
-                    <Rectangle Height="3" Fill="#FFE5E7EB" Margin="0,2"/>
-                    <Rectangle Height="3" Fill="#FFE5E7EB" Margin="0,2"/>
-                    <Rectangle Height="3" Fill="#FFE5E7EB" Margin="0,2"/>
-                </StackPanel>
-            </Button>
+            <Border Grid.Column="0" Background="#FF232529" BorderBrush="#FF3B3F45" BorderThickness="1" CornerRadius="4">
+                <Button x:Name="HamburgerButton" Background="Transparent" BorderThickness="0" ToolTip="Menu" Cursor="Hand">
+                    <StackPanel VerticalAlignment="Center" Margin="8,6">
+                        <Rectangle Height="3" Fill="#FFE5E7EB" Margin="0,2"/>
+                        <Rectangle Height="3" Fill="#FFE5E7EB" Margin="0,2"/>
+                        <Rectangle Height="3" Fill="#FFE5E7EB" Margin="0,2"/>
+                    </StackPanel>
+                </Button>
+            </Border>
 
             <Popup x:Name="HamburgerPopup" PlacementTarget="{Binding ElementName=HamburgerButton}" StaysOpen="False">
                 <menus:FileMenu />


### PR DESCRIPTION
## Summary
- Wrap hamburger menu button in a bordered container to apply corner radius with built-in WPF properties

## Testing
- `dotnet build` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68a4fa14514083308062a488cb1076a9