### PR TITLE
0.0.3 - Visual UI updates

### DIFF
--- a/WordForge/MainWindow.xaml
+++ b/WordForge/MainWindow.xaml
@@ -9,7 +9,7 @@
 
     <Grid>
         <Grid.RowDefinitions>
-            <RowDefinition Height="92"/>
+            <RowDefinition Height="120"/>
             <!-- Taller top bar -->
             <RowDefinition Height="*"/>
             <!-- Main area -->
@@ -23,7 +23,7 @@
         <!-- ===== MAIN AREA (left rail + center + right pane ~25%) ===== -->
         <Grid Grid.Row="1">
             <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="64"/>
+                <ColumnDefinition Width="112"/>
                 <!-- Left vertical nav -->
                 <ColumnDefinition Width="3*"/>
                 <!-- Center editor -->
@@ -35,37 +35,37 @@
             <Border Grid.Column="0" Background="#FF232529" BorderBrush="#FF0F1012" BorderThickness="0,0,1,0">
                 <StackPanel Margin="8">
                     <!-- Buttons: Transcript, Timeline, Outline, Character Bible, Location Bible, Item Bible -->
-                    <Button Height="56" Margin="0,0,0,8" Background="#FF2A2D31" BorderBrush="#FF3B3F45" Foreground="#FFE5E7EB" Cursor="Hand">
+                    <Button Width="96" Height="56" Margin="0,0,0,8" Background="#FF2A2D31" BorderBrush="#FF3B3F45" Foreground="#FFE5E7EB" Cursor="Hand">
                         <StackPanel>
                             <Rectangle Height="20" Width="20" Fill="#FFBFC5CD" HorizontalAlignment="Center" Margin="0,4,0,2"/>
                             <TextBlock Text="TRANSCRIPT" FontWeight="Bold" FontSize="10" HorizontalAlignment="Center"/>
                         </StackPanel>
                     </Button>
-                    <Button Height="56" Margin="0,0,0,8" Background="#FF2A2D31" BorderBrush="#FF3B3F45" Foreground="#FFE5E7EB" Cursor="Hand">
+                    <Button Width="96" Height="56" Margin="0,0,0,8" Background="#FF2A2D31" BorderBrush="#FF3B3F45" Foreground="#FFE5E7EB" Cursor="Hand">
                         <StackPanel>
                             <Rectangle Height="20" Width="20" Fill="#FFBFC5CD" HorizontalAlignment="Center" Margin="0,4,0,2"/>
                             <TextBlock Text="TIMELINE" FontWeight="Bold" FontSize="10" HorizontalAlignment="Center"/>
                         </StackPanel>
                     </Button>
-                    <Button Height="56" Margin="0,0,0,8" Background="#FF2A2D31" BorderBrush="#FF3B3F45" Foreground="#FFE5E7EB" Cursor="Hand">
+                    <Button Width="96" Height="56" Margin="0,0,0,8" Background="#FF2A2D31" BorderBrush="#FF3B3F45" Foreground="#FFE5E7EB" Cursor="Hand">
                         <StackPanel>
                             <Rectangle Height="20" Width="20" Fill="#FFBFC5CD" HorizontalAlignment="Center" Margin="0,4,0,2"/>
                             <TextBlock Text="OUTLINE" FontWeight="Bold" FontSize="10" HorizontalAlignment="Center"/>
                         </StackPanel>
                     </Button>
-                    <Button Height="56" Margin="0,0,0,8" Background="#FF2A2D31" BorderBrush="#FF3B3F45" Foreground="#FFE5E7EB" Cursor="Hand">
+                    <Button Width="96" Height="56" Margin="0,0,0,8" Background="#FF2A2D31" BorderBrush="#FF3B3F45" Foreground="#FFE5E7EB" Cursor="Hand">
                         <StackPanel>
                             <Rectangle Height="20" Width="20" Fill="#FFBFC5CD" HorizontalAlignment="Center" Margin="0,4,0,2"/>
                             <TextBlock Text="CHAR BIBLE" FontWeight="Bold" FontSize="10" HorizontalAlignment="Center"/>
                         </StackPanel>
                     </Button>
-                    <Button Height="56" Margin="0,0,0,8" Background="#FF2A2D31" BorderBrush="#FF3B3F45" Foreground="#FFE5E7EB" Cursor="Hand">
+                    <Button Width="96" Height="56" Margin="0,0,0,8" Background="#FF2A2D31" BorderBrush="#FF3B3F45" Foreground="#FFE5E7EB" Cursor="Hand">
                         <StackPanel>
                             <Rectangle Height="20" Width="20" Fill="#FFBFC5CD" HorizontalAlignment="Center" Margin="0,4,0,2"/>
                             <TextBlock Text="LOC BIBLE" FontWeight="Bold" FontSize="10" HorizontalAlignment="Center"/>
                         </StackPanel>
                     </Button>
-                    <Button Height="56" Background="#FF2A2D31" BorderBrush="#FF3B3F45" Foreground="#FFE5E7EB" Cursor="Hand">
+                    <Button Width="96" Height="56" Background="#FF2A2D31" BorderBrush="#FF3B3F45" Foreground="#FFE5E7EB" Cursor="Hand">
                         <StackPanel>
                             <Rectangle Height="20" Width="20" Fill="#FFBFC5CD" HorizontalAlignment="Center" Margin="0,4,0,2"/>
                             <TextBlock Text="ITEM BIBLE" FontWeight="Bold" FontSize="10" HorizontalAlignment="Center"/>
@@ -75,7 +75,7 @@
             </Border>
 
             <!-- Center editor surface -->
-            <Grid Grid.Column="1" Background="#FF1A1B1E" Margin="12,8,12,8">
+            <Grid Grid.Column="1" Background="#FF1A1B1E" Margin="12,0,12,0">
                 <Grid.RowDefinitions>
                     <RowDefinition Height="28"/>
                     <!-- Section title -->
@@ -101,7 +101,7 @@
             </Grid>
 
             <!-- Right pane (~25%) -->
-            <Border Grid.Column="2" Margin="0,8,12,8" Background="#FF232529"
+            <Border Grid.Column="2" Margin="0,0,12,0" Background="#FF232529"
                     BorderBrush="#FF3B3F45" BorderThickness="1" CornerRadius="6">
                 <Grid>
                     <TextBlock Text="RIGHT PANE" Foreground="#FFE5E7EB" FontWeight="Bold"

--- a/WordForge/menus/topmenu/TranscriptMenu.xaml
+++ b/WordForge/menus/topmenu/TranscriptMenu.xaml
@@ -17,28 +17,28 @@
                 <ColumnDefinition Width="120"/>
                 <!-- Outline -->
                 <ColumnDefinition Width="18"/>
-                <ColumnDefinition Width="210"/>
+                <ColumnDefinition Width="330"/>
                 <!-- Bibles group -->
                 <ColumnDefinition Width="*"/>
             </Grid.ColumnDefinitions>
 
             <!-- Hamburger -->
-            <Border Grid.Column="0" Background="#FF232529" BorderBrush="#FF3B3F45" BorderThickness="1" CornerRadius="4">
-                <Button x:Name="HamburgerButton" Background="Transparent" BorderThickness="0" ToolTip="Menu" Cursor="Hand">
-                    <StackPanel VerticalAlignment="Center" Margin="8,6">
-                        <Rectangle Height="3" Fill="#FFE5E7EB" Margin="0,2"/>
-                        <Rectangle Height="3" Fill="#FFE5E7EB" Margin="0,2"/>
-                        <Rectangle Height="3" Fill="#FFE5E7EB" Margin="0,2"/>
-                    </StackPanel>
-                </Button>
-            </Border>
+            <Button x:Name="HamburgerButton" Grid.Column="0" Background="Transparent" BorderBrush="#FF3B3F45" BorderThickness="1" CornerRadius="4" ToolTip="Menu" Cursor="Hand">
+                <StackPanel VerticalAlignment="Center" Margin="8,6">
+                    <Rectangle Height="3" Fill="#FFE5E7EB" Margin="0,2"/>
+                    <Rectangle Height="3" Fill="#FFE5E7EB" Margin="0,2"/>
+                    <Rectangle Height="3" Fill="#FFE5E7EB" Margin="0,2"/>
+                </StackPanel>
+            </Button>
 
             <Popup x:Name="HamburgerPopup" PlacementTarget="{Binding ElementName=HamburgerButton}" StaysOpen="False">
                 <menus:FileMenu />
             </Popup>
 
             <!-- Right Pane label -->
-            <TextBlock Grid.Column="2" Text="Right Pane" Foreground="#FFE5E7EB" FontWeight="Bold" VerticalAlignment="Center"/>
+            <Border Grid.Column="2" Padding="12,6" Background="#FF2E3136" BorderBrush="#FF3B3F45" BorderThickness="1" CornerRadius="12" VerticalAlignment="Center" HorizontalAlignment="Left">
+                <TextBlock Text="Right Pane" Foreground="#FFE5E7EB" FontWeight="SemiBold" />
+            </Border>
 
             <!-- Timeline button -->
             <Button Grid.Column="4" Height="52" Background="#FFE5E7EB" BorderBrush="#FF9CA3AF"
@@ -56,8 +56,8 @@
                         <RowDefinition Height="8"/>
                         <RowDefinition Height="*"/>
                     </Grid.RowDefinitions>
-                    <TextBlock Text="Bibles" Foreground="#FFE5E7EB" FontWeight="Bold"/>
-                    <StackPanel Grid.Row="2" Orientation="Horizontal" HorizontalAlignment="Left">
+                    <TextBlock Text="Bibles" Foreground="#FFE5E7EB" FontWeight="Bold" HorizontalAlignment="Center"/>
+                    <StackPanel Grid.Row="2" Orientation="Horizontal" HorizontalAlignment="Center">
                         <Button Width="90" Height="36" Margin="0,0,8,0"
                                 Background="#FFE5E7EB" BorderBrush="#FF9CA3AF"
                                 Foreground="#FF111111" FontWeight="SemiBold" Content="Character"/>


### PR DESCRIPTION
## Summary
- increase top menu height and widen left navigation for better spacing
- restyle top bar elements including hamburger icon, pill label, and centered Bibles group buttons
- align main content panes for uniform height

## Testing
- `dotnet build` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68a4fec737888330bb68ef30de9ade25