### PR TITLE
0.0.4 - Menus corrected

### DIFF
--- a/WordForge/MainWindow.xaml
+++ b/WordForge/MainWindow.xaml
@@ -1,7 +1,7 @@
 <Window x:Class="WordForge.MainWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        xmlns:topmenu="clr-namespace:WordForge.Menus.TopMenu"
+        xmlns:menus="clr-namespace:WordForge.Menus"
         Title="WordForge - New Project" Height="800" Width="1280"
         WindowStartupLocation="CenterScreen"
         Background="#FF1A1B1E"
@@ -18,7 +18,7 @@
         </Grid.RowDefinitions>
 
         <!-- ===== TOP BAR ===== -->
-        <topmenu:TranscriptMenu Grid.Row="0"/>
+        <ContentControl x:Name="TopMenuContent" Grid.Row="0"/>
 
         <!-- ===== MAIN AREA (left rail + center + right pane ~25%) ===== -->
         <Grid Grid.Row="1">
@@ -32,47 +32,7 @@
             </Grid.ColumnDefinitions>
 
             <!-- Left vertical nav -->
-            <Border Grid.Column="0" Background="#FF232529" BorderBrush="#FF0F1012" BorderThickness="0,0,1,0">
-                <StackPanel Margin="8">
-                    <!-- Buttons: Transcript, Timeline, Outline, Character Bible, Location Bible, Item Bible -->
-                    <Button Width="96" Height="56" Margin="0,0,0,8" Background="#FF2A2D31" BorderBrush="#FF3B3F45" Foreground="#FFE5E7EB" Cursor="Hand">
-                        <StackPanel>
-                            <Rectangle Height="20" Width="20" Fill="#FFBFC5CD" HorizontalAlignment="Center" Margin="0,4,0,2"/>
-                            <TextBlock Text="TRANSCRIPT" FontWeight="Bold" FontSize="10" HorizontalAlignment="Center"/>
-                        </StackPanel>
-                    </Button>
-                    <Button Width="96" Height="56" Margin="0,0,0,8" Background="#FF2A2D31" BorderBrush="#FF3B3F45" Foreground="#FFE5E7EB" Cursor="Hand">
-                        <StackPanel>
-                            <Rectangle Height="20" Width="20" Fill="#FFBFC5CD" HorizontalAlignment="Center" Margin="0,4,0,2"/>
-                            <TextBlock Text="TIMELINE" FontWeight="Bold" FontSize="10" HorizontalAlignment="Center"/>
-                        </StackPanel>
-                    </Button>
-                    <Button Width="96" Height="56" Margin="0,0,0,8" Background="#FF2A2D31" BorderBrush="#FF3B3F45" Foreground="#FFE5E7EB" Cursor="Hand">
-                        <StackPanel>
-                            <Rectangle Height="20" Width="20" Fill="#FFBFC5CD" HorizontalAlignment="Center" Margin="0,4,0,2"/>
-                            <TextBlock Text="OUTLINE" FontWeight="Bold" FontSize="10" HorizontalAlignment="Center"/>
-                        </StackPanel>
-                    </Button>
-                    <Button Width="96" Height="56" Margin="0,0,0,8" Background="#FF2A2D31" BorderBrush="#FF3B3F45" Foreground="#FFE5E7EB" Cursor="Hand">
-                        <StackPanel>
-                            <Rectangle Height="20" Width="20" Fill="#FFBFC5CD" HorizontalAlignment="Center" Margin="0,4,0,2"/>
-                            <TextBlock Text="CHAR BIBLE" FontWeight="Bold" FontSize="10" HorizontalAlignment="Center"/>
-                        </StackPanel>
-                    </Button>
-                    <Button Width="96" Height="56" Margin="0,0,0,8" Background="#FF2A2D31" BorderBrush="#FF3B3F45" Foreground="#FFE5E7EB" Cursor="Hand">
-                        <StackPanel>
-                            <Rectangle Height="20" Width="20" Fill="#FFBFC5CD" HorizontalAlignment="Center" Margin="0,4,0,2"/>
-                            <TextBlock Text="LOC BIBLE" FontWeight="Bold" FontSize="10" HorizontalAlignment="Center"/>
-                        </StackPanel>
-                    </Button>
-                    <Button Width="96" Height="56" Background="#FF2A2D31" BorderBrush="#FF3B3F45" Foreground="#FFE5E7EB" Cursor="Hand">
-                        <StackPanel>
-                            <Rectangle Height="20" Width="20" Fill="#FFBFC5CD" HorizontalAlignment="Center" Margin="0,4,0,2"/>
-                            <TextBlock Text="ITEM BIBLE" FontWeight="Bold" FontSize="10" HorizontalAlignment="Center"/>
-                        </StackPanel>
-                    </Button>
-                </StackPanel>
-            </Border>
+            <menus:LeftMenu Grid.Column="0"/>
 
             <!-- Center editor surface -->
             <Grid Grid.Column="1" Background="#FF1A1B1E" Margin="12,0,12,0">

--- a/WordForge/MainWindow.xaml.cs
+++ b/WordForge/MainWindow.xaml.cs
@@ -8,6 +8,7 @@ using System.Windows.Media;
 using System.Windows.Media.Imaging;
 using System.Windows.Navigation;
 using System.Windows.Shapes;
+using WordForge.Menus.TopMenu;
 
 namespace WordForge
 {
@@ -19,6 +20,7 @@ namespace WordForge
         public MainWindow()
         {
             InitializeComponent();
+            TopMenuContent.Content = new TranscriptMenu();
         }
     }
 }

--- a/WordForge/menus/LeftMenu.xaml
+++ b/WordForge/menus/LeftMenu.xaml
@@ -1,0 +1,44 @@
+<UserControl x:Class="WordForge.Menus.LeftMenu"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <Border Background="#FF232529" BorderBrush="#FF0F1012" BorderThickness="0,0,1,0">
+        <StackPanel Margin="8">
+            <Button x:Name="TranscriptButton" Width="96" Height="56" Margin="0,0,0,8" Background="#FF2A2D31" BorderBrush="#FF3B3F45" Foreground="#FFE5E7EB" Cursor="Hand" Click="TranscriptButton_Click">
+                <StackPanel>
+                    <Rectangle Height="20" Width="20" Fill="#FFBFC5CD" HorizontalAlignment="Center" Margin="0,4,0,2"/>
+                    <TextBlock Text="TRANSCRIPT" FontWeight="Bold" FontSize="10" HorizontalAlignment="Center"/>
+                </StackPanel>
+            </Button>
+            <Button x:Name="TimelineButton" Width="96" Height="56" Margin="0,0,0,8" Background="#FF2A2D31" BorderBrush="#FF3B3F45" Foreground="#FFE5E7EB" Cursor="Hand" Click="TimelineButton_Click">
+                <StackPanel>
+                    <Rectangle Height="20" Width="20" Fill="#FFBFC5CD" HorizontalAlignment="Center" Margin="0,4,0,2"/>
+                    <TextBlock Text="TIMELINE" FontWeight="Bold" FontSize="10" HorizontalAlignment="Center"/>
+                </StackPanel>
+            </Button>
+            <Button x:Name="OutlineButton" Width="96" Height="56" Margin="0,0,0,8" Background="#FF2A2D31" BorderBrush="#FF3B3F45" Foreground="#FFE5E7EB" Cursor="Hand" Click="OutlineButton_Click">
+                <StackPanel>
+                    <Rectangle Height="20" Width="20" Fill="#FFBFC5CD" HorizontalAlignment="Center" Margin="0,4,0,2"/>
+                    <TextBlock Text="OUTLINE" FontWeight="Bold" FontSize="10" HorizontalAlignment="Center"/>
+                </StackPanel>
+            </Button>
+            <Button x:Name="CharacterBibleButton" Width="96" Height="56" Margin="0,0,0,8" Background="#FF2A2D31" BorderBrush="#FF3B3F45" Foreground="#FFE5E7EB" Cursor="Hand" Click="CharacterBibleButton_Click">
+                <StackPanel>
+                    <Rectangle Height="20" Width="20" Fill="#FFBFC5CD" HorizontalAlignment="Center" Margin="0,4,0,2"/>
+                    <TextBlock Text="CHAR BIBLE" FontWeight="Bold" FontSize="10" HorizontalAlignment="Center"/>
+                </StackPanel>
+            </Button>
+            <Button x:Name="LocationBibleButton" Width="96" Height="56" Margin="0,0,0,8" Background="#FF2A2D31" BorderBrush="#FF3B3F45" Foreground="#FFE5E7EB" Cursor="Hand" Click="LocationBibleButton_Click">
+                <StackPanel>
+                    <Rectangle Height="20" Width="20" Fill="#FFBFC5CD" HorizontalAlignment="Center" Margin="0,4,0,2"/>
+                    <TextBlock Text="LOC BIBLE" FontWeight="Bold" FontSize="10" HorizontalAlignment="Center"/>
+                </StackPanel>
+            </Button>
+            <Button x:Name="ItemBibleButton" Width="96" Height="56" Background="#FF2A2D31" BorderBrush="#FF3B3F45" Foreground="#FFE5E7EB" Cursor="Hand" Click="ItemBibleButton_Click">
+                <StackPanel>
+                    <Rectangle Height="20" Width="20" Fill="#FFBFC5CD" HorizontalAlignment="Center" Margin="0,4,0,2"/>
+                    <TextBlock Text="ITEM BIBLE" FontWeight="Bold" FontSize="10" HorizontalAlignment="Center"/>
+                </StackPanel>
+            </Button>
+        </StackPanel>
+    </Border>
+</UserControl>

--- a/WordForge/menus/LeftMenu.xaml.cs
+++ b/WordForge/menus/LeftMenu.xaml.cs
@@ -1,0 +1,43 @@
+using System.Windows;
+using System.Windows.Controls;
+using WordForge.Menus.TopMenu;
+
+namespace WordForge.Menus;
+
+public partial class LeftMenu : UserControl
+{
+    public LeftMenu()
+    {
+        InitializeComponent();
+    }
+
+    private void TranscriptButton_Click(object sender, RoutedEventArgs e)
+    {
+        ((MainWindow)Application.Current.MainWindow).TopMenuContent.Content = new TranscriptMenu();
+    }
+
+    private void TimelineButton_Click(object sender, RoutedEventArgs e)
+    {
+        ((MainWindow)Application.Current.MainWindow).TopMenuContent.Content = new TimelineMenu();
+    }
+
+    private void OutlineButton_Click(object sender, RoutedEventArgs e)
+    {
+        ((MainWindow)Application.Current.MainWindow).TopMenuContent.Content = new OutlineMenu();
+    }
+
+    private void CharacterBibleButton_Click(object sender, RoutedEventArgs e)
+    {
+        ((MainWindow)Application.Current.MainWindow).TopMenuContent.Content = new CharacterBibleMenu();
+    }
+
+    private void LocationBibleButton_Click(object sender, RoutedEventArgs e)
+    {
+        ((MainWindow)Application.Current.MainWindow).TopMenuContent.Content = new LocationBibleMenu();
+    }
+
+    private void ItemBibleButton_Click(object sender, RoutedEventArgs e)
+    {
+        ((MainWindow)Application.Current.MainWindow).TopMenuContent.Content = new ItemBibleMenu();
+    }
+}

--- a/WordForge/menus/topmenu/CharacterBibleMenu.xaml
+++ b/WordForge/menus/topmenu/CharacterBibleMenu.xaml
@@ -1,4 +1,4 @@
-<UserControl x:Class="WordForge.Menus.TopMenu.TranscriptMenu"
+<UserControl x:Class="WordForge.Menus.TopMenu.CharacterBibleMenu"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:menus="clr-namespace:WordForge.Menus">
@@ -54,9 +54,6 @@
                     </Grid.RowDefinitions>
                     <TextBlock Text="Bibles" Foreground="#FFE5E7EB" FontWeight="Bold" HorizontalAlignment="Center"/>
                     <StackPanel Grid.Row="2" Orientation="Horizontal" HorizontalAlignment="Center">
-                        <Button Width="90" Height="36" Margin="0,0,8,0"
-                                Background="#FFE5E7EB" BorderBrush="#FF9CA3AF"
-                                Foreground="#FF111111" FontWeight="SemiBold" Content="Character"/>
                         <Button Width="90" Height="36" Margin="0,0,8,0"
                                 Background="#FFE5E7EB" BorderBrush="#FF9CA3AF"
                                 Foreground="#FF111111" FontWeight="SemiBold" Content="Location"/>

--- a/WordForge/menus/topmenu/CharacterBibleMenu.xaml.cs
+++ b/WordForge/menus/topmenu/CharacterBibleMenu.xaml.cs
@@ -1,0 +1,18 @@
+using System.Windows;
+using System.Windows.Controls;
+
+namespace WordForge.Menus.TopMenu;
+
+public partial class CharacterBibleMenu : UserControl
+{
+    public CharacterBibleMenu()
+    {
+        InitializeComponent();
+        HamburgerButton.Click += HamburgerButton_Click;
+    }
+
+    private void HamburgerButton_Click(object sender, RoutedEventArgs e)
+    {
+        HamburgerPopup.IsOpen = !HamburgerPopup.IsOpen;
+    }
+}

--- a/WordForge/menus/topmenu/ItemBibleMenu.xaml
+++ b/WordForge/menus/topmenu/ItemBibleMenu.xaml
@@ -1,4 +1,4 @@
-<UserControl x:Class="WordForge.Menus.TopMenu.TranscriptMenu"
+<UserControl x:Class="WordForge.Menus.TopMenu.ItemBibleMenu"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:menus="clr-namespace:WordForge.Menus">
@@ -57,12 +57,9 @@
                         <Button Width="90" Height="36" Margin="0,0,8,0"
                                 Background="#FFE5E7EB" BorderBrush="#FF9CA3AF"
                                 Foreground="#FF111111" FontWeight="SemiBold" Content="Character"/>
-                        <Button Width="90" Height="36" Margin="0,0,8,0"
-                                Background="#FFE5E7EB" BorderBrush="#FF9CA3AF"
-                                Foreground="#FF111111" FontWeight="SemiBold" Content="Location"/>
                         <Button Width="90" Height="36"
                                 Background="#FFE5E7EB" BorderBrush="#FF9CA3AF"
-                                Foreground="#FF111111" FontWeight="SemiBold" Content="Item"/>
+                                Foreground="#FF111111" FontWeight="SemiBold" Content="Location"/>
                     </StackPanel>
                 </Grid>
             </Border>

--- a/WordForge/menus/topmenu/ItemBibleMenu.xaml.cs
+++ b/WordForge/menus/topmenu/ItemBibleMenu.xaml.cs
@@ -1,0 +1,18 @@
+using System.Windows;
+using System.Windows.Controls;
+
+namespace WordForge.Menus.TopMenu;
+
+public partial class ItemBibleMenu : UserControl
+{
+    public ItemBibleMenu()
+    {
+        InitializeComponent();
+        HamburgerButton.Click += HamburgerButton_Click;
+    }
+
+    private void HamburgerButton_Click(object sender, RoutedEventArgs e)
+    {
+        HamburgerPopup.IsOpen = !HamburgerPopup.IsOpen;
+    }
+}

--- a/WordForge/menus/topmenu/LocationBibleMenu.xaml
+++ b/WordForge/menus/topmenu/LocationBibleMenu.xaml
@@ -1,4 +1,4 @@
-<UserControl x:Class="WordForge.Menus.TopMenu.TranscriptMenu"
+<UserControl x:Class="WordForge.Menus.TopMenu.LocationBibleMenu"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:menus="clr-namespace:WordForge.Menus">
@@ -57,9 +57,6 @@
                         <Button Width="90" Height="36" Margin="0,0,8,0"
                                 Background="#FFE5E7EB" BorderBrush="#FF9CA3AF"
                                 Foreground="#FF111111" FontWeight="SemiBold" Content="Character"/>
-                        <Button Width="90" Height="36" Margin="0,0,8,0"
-                                Background="#FFE5E7EB" BorderBrush="#FF9CA3AF"
-                                Foreground="#FF111111" FontWeight="SemiBold" Content="Location"/>
                         <Button Width="90" Height="36"
                                 Background="#FFE5E7EB" BorderBrush="#FF9CA3AF"
                                 Foreground="#FF111111" FontWeight="SemiBold" Content="Item"/>

--- a/WordForge/menus/topmenu/LocationBibleMenu.xaml.cs
+++ b/WordForge/menus/topmenu/LocationBibleMenu.xaml.cs
@@ -1,0 +1,18 @@
+using System.Windows;
+using System.Windows.Controls;
+
+namespace WordForge.Menus.TopMenu;
+
+public partial class LocationBibleMenu : UserControl
+{
+    public LocationBibleMenu()
+    {
+        InitializeComponent();
+        HamburgerButton.Click += HamburgerButton_Click;
+    }
+
+    private void HamburgerButton_Click(object sender, RoutedEventArgs e)
+    {
+        HamburgerPopup.IsOpen = !HamburgerPopup.IsOpen;
+    }
+}

--- a/WordForge/menus/topmenu/OutlineMenu.xaml
+++ b/WordForge/menus/topmenu/OutlineMenu.xaml
@@ -1,4 +1,4 @@
-<UserControl x:Class="WordForge.Menus.TopMenu.TranscriptMenu"
+<UserControl x:Class="WordForge.Menus.TopMenu.OutlineMenu"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:menus="clr-namespace:WordForge.Menus">
@@ -13,9 +13,6 @@
                 <ColumnDefinition Width="16"/>
                 <ColumnDefinition Width="120"/>
                 <!-- Timeline -->
-                <ColumnDefinition Width="12"/>
-                <ColumnDefinition Width="120"/>
-                <!-- Outline -->
                 <ColumnDefinition Width="18"/>
                 <ColumnDefinition Width="330"/>
                 <!-- Bibles group -->
@@ -40,12 +37,8 @@
             <Button Grid.Column="4" Height="52" Background="#FFE5E7EB" BorderBrush="#FF9CA3AF"
                     Foreground="#FF111111" FontWeight="Bold" Cursor="Hand" Content="Timeline"/>
 
-            <!-- Outline button -->
-            <Button Grid.Column="6" Height="52" Background="#FFE5E7EB" BorderBrush="#FF9CA3AF"
-                    Foreground="#FF111111" FontWeight="Bold" Cursor="Hand" Content="Outline"/>
-
             <!-- Bibles group -->
-            <Border Grid.Column="8" Background="#FF232529" BorderBrush="#FF3B3F45" BorderThickness="1" CornerRadius="6" Padding="10">
+            <Border Grid.Column="6" Background="#FF232529" BorderBrush="#FF3B3F45" BorderThickness="1" CornerRadius="6" Padding="10">
                 <Grid>
                     <Grid.RowDefinitions>
                         <RowDefinition Height="Auto"/>

--- a/WordForge/menus/topmenu/OutlineMenu.xaml.cs
+++ b/WordForge/menus/topmenu/OutlineMenu.xaml.cs
@@ -1,0 +1,18 @@
+using System.Windows;
+using System.Windows.Controls;
+
+namespace WordForge.Menus.TopMenu;
+
+public partial class OutlineMenu : UserControl
+{
+    public OutlineMenu()
+    {
+        InitializeComponent();
+        HamburgerButton.Click += HamburgerButton_Click;
+    }
+
+    private void HamburgerButton_Click(object sender, RoutedEventArgs e)
+    {
+        HamburgerPopup.IsOpen = !HamburgerPopup.IsOpen;
+    }
+}

--- a/WordForge/menus/topmenu/TimelineMenu.xaml
+++ b/WordForge/menus/topmenu/TimelineMenu.xaml
@@ -1,4 +1,4 @@
-<UserControl x:Class="WordForge.Menus.TopMenu.TranscriptMenu"
+<UserControl x:Class="WordForge.Menus.TopMenu.TimelineMenu"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:menus="clr-namespace:WordForge.Menus">
@@ -11,9 +11,6 @@
                 <ColumnDefinition Width="140"/>
                 <!-- Title 'Right Pane' -->
                 <ColumnDefinition Width="16"/>
-                <ColumnDefinition Width="120"/>
-                <!-- Timeline -->
-                <ColumnDefinition Width="12"/>
                 <ColumnDefinition Width="120"/>
                 <!-- Outline -->
                 <ColumnDefinition Width="18"/>
@@ -36,16 +33,12 @@
                 <TextBlock Text="Right Pane" Foreground="#FFE5E7EB" FontWeight="SemiBold" />
             </Border>
 
-            <!-- Timeline button -->
-            <Button Grid.Column="4" Height="52" Background="#FFE5E7EB" BorderBrush="#FF9CA3AF"
-                    Foreground="#FF111111" FontWeight="Bold" Cursor="Hand" Content="Timeline"/>
-
             <!-- Outline button -->
-            <Button Grid.Column="6" Height="52" Background="#FFE5E7EB" BorderBrush="#FF9CA3AF"
+            <Button Grid.Column="4" Height="52" Background="#FFE5E7EB" BorderBrush="#FF9CA3AF"
                     Foreground="#FF111111" FontWeight="Bold" Cursor="Hand" Content="Outline"/>
 
             <!-- Bibles group -->
-            <Border Grid.Column="8" Background="#FF232529" BorderBrush="#FF3B3F45" BorderThickness="1" CornerRadius="6" Padding="10">
+            <Border Grid.Column="6" Background="#FF232529" BorderBrush="#FF3B3F45" BorderThickness="1" CornerRadius="6" Padding="10">
                 <Grid>
                     <Grid.RowDefinitions>
                         <RowDefinition Height="Auto"/>

--- a/WordForge/menus/topmenu/TimelineMenu.xaml.cs
+++ b/WordForge/menus/topmenu/TimelineMenu.xaml.cs
@@ -1,0 +1,18 @@
+using System.Windows;
+using System.Windows.Controls;
+
+namespace WordForge.Menus.TopMenu;
+
+public partial class TimelineMenu : UserControl
+{
+    public TimelineMenu()
+    {
+        InitializeComponent();
+        HamburgerButton.Click += HamburgerButton_Click;
+    }
+
+    private void HamburgerButton_Click(object sender, RoutedEventArgs e)
+    {
+        HamburgerPopup.IsOpen = !HamburgerPopup.IsOpen;
+    }
+}


### PR DESCRIPTION
## Summary
- Replace hamburger placeholder with image asset
- Add timeline, outline, and bible top menus
- Move left navigation into reusable control and hook switching logic

## Testing
- `apt-get install -y dotnet-sdk-8.0`
- `dotnet build` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68a5152bd03483308516d511b8639ed3