### PR TITLE
0.0.5 - Right Panes Wired

### DIFF
--- a/WordForge/MainWindow.xaml
+++ b/WordForge/MainWindow.xaml
@@ -63,10 +63,7 @@
             <!-- Right pane (~25%) -->
             <Border Grid.Column="2" Margin="0,0,12,0" Background="#FF232529"
                     BorderBrush="#FF3B3F45" BorderThickness="1" CornerRadius="6">
-                <Grid>
-                    <TextBlock Text="RIGHT PANE" Foreground="#FFE5E7EB" FontWeight="Bold"
-                               Margin="10" HorizontalAlignment="Left" VerticalAlignment="Top"/>
-                </Grid>
+                <ContentControl x:Name="RightPaneContent"/>
             </Border>
         </Grid>
 

--- a/WordForge/MainWindow.xaml.cs
+++ b/WordForge/MainWindow.xaml.cs
@@ -20,7 +20,9 @@ namespace WordForge
         public MainWindow()
         {
             InitializeComponent();
+            RightPaneService.Host = RightPaneContent;
             TopMenuContent.Content = new TranscriptMenu();
+            RightPaneService.Show(RightPaneKind.Timeline);
         }
     }
 }

--- a/WordForge/RightPaneService.cs
+++ b/WordForge/RightPaneService.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Windows.Controls;
+using System.Windows.Media;
+using WordForge.Panes;
+
+namespace WordForge;
+
+public enum RightPaneKind
+{
+    Timeline,
+    Outline,
+    Character,
+    Location,
+    Item
+}
+
+public static class RightPaneService
+{
+    public static ContentControl? Host { get; set; }
+
+    public static RightPaneKind CurrentPane { get; private set; } = RightPaneKind.Timeline;
+
+    public static event Action<RightPaneKind>? PaneChanged;
+
+    public static void Show(RightPaneKind kind)
+    {
+        if (Host != null)
+        {
+            Host.Content = kind switch
+            {
+                RightPaneKind.Timeline => new TimelinePane(),
+                RightPaneKind.Outline => new OutlinePane(),
+                RightPaneKind.Character => new CharacterBiblePane(),
+                RightPaneKind.Location => new LocationBiblePane(),
+                RightPaneKind.Item => new ItemBiblePane(),
+                _ => new TimelinePane()
+            };
+        }
+        CurrentPane = kind;
+        PaneChanged?.Invoke(kind);
+    }
+
+    public static void BindButton(Button button, RightPaneKind kind)
+    {
+        button.Click += (_, __) => Show(kind);
+        PaneChanged += pane => SetActive(button, pane == kind);
+        SetActive(button, CurrentPane == kind);
+    }
+
+    private static void SetActive(Button button, bool active)
+    {
+        var activeBrush = (Brush)new BrushConverter().ConvertFrom("#FF30D158")!;
+        var inactiveBrush = (Brush)new BrushConverter().ConvertFrom("#FFE5E7EB")!;
+        var activeForeground = Brushes.White;
+        var inactiveForeground = (Brush)new BrushConverter().ConvertFrom("#FF111111")!;
+        button.Background = active ? activeBrush : inactiveBrush;
+        button.Foreground = active ? activeForeground : inactiveForeground;
+    }
+}

--- a/WordForge/menus/topmenu/CharacterBibleMenu.xaml
+++ b/WordForge/menus/topmenu/CharacterBibleMenu.xaml
@@ -37,11 +37,11 @@
             </Border>
 
             <!-- Timeline button -->
-            <Button Grid.Column="4" Height="52" Background="#FFE5E7EB" BorderBrush="#FF9CA3AF"
+            <Button x:Name="TimelineButton" Grid.Column="4" Height="52" Background="#FFE5E7EB" BorderBrush="#FF9CA3AF"
                     Foreground="#FF111111" FontWeight="Bold" Cursor="Hand" Content="Timeline"/>
 
             <!-- Outline button -->
-            <Button Grid.Column="6" Height="52" Background="#FFE5E7EB" BorderBrush="#FF9CA3AF"
+            <Button x:Name="OutlineButton" Grid.Column="6" Height="52" Background="#FFE5E7EB" BorderBrush="#FF9CA3AF"
                     Foreground="#FF111111" FontWeight="Bold" Cursor="Hand" Content="Outline"/>
 
             <!-- Bibles group -->
@@ -54,10 +54,10 @@
                     </Grid.RowDefinitions>
                     <TextBlock Text="Bibles" Foreground="#FFE5E7EB" FontWeight="Bold" HorizontalAlignment="Center"/>
                     <StackPanel Grid.Row="2" Orientation="Horizontal" HorizontalAlignment="Center">
-                        <Button Width="90" Height="36" Margin="0,0,8,0"
+                        <Button x:Name="LocationButton" Width="90" Height="36" Margin="0,0,8,0"
                                 Background="#FFE5E7EB" BorderBrush="#FF9CA3AF"
                                 Foreground="#FF111111" FontWeight="SemiBold" Content="Location"/>
-                        <Button Width="90" Height="36"
+                        <Button x:Name="ItemButton" Width="90" Height="36"
                                 Background="#FFE5E7EB" BorderBrush="#FF9CA3AF"
                                 Foreground="#FF111111" FontWeight="SemiBold" Content="Item"/>
                     </StackPanel>

--- a/WordForge/menus/topmenu/CharacterBibleMenu.xaml.cs
+++ b/WordForge/menus/topmenu/CharacterBibleMenu.xaml.cs
@@ -1,5 +1,6 @@
 using System.Windows;
 using System.Windows.Controls;
+using WordForge;
 
 namespace WordForge.Menus.TopMenu;
 
@@ -9,6 +10,10 @@ public partial class CharacterBibleMenu : UserControl
     {
         InitializeComponent();
         HamburgerButton.Click += HamburgerButton_Click;
+        RightPaneService.BindButton(TimelineButton, RightPaneKind.Timeline);
+        RightPaneService.BindButton(OutlineButton, RightPaneKind.Outline);
+        RightPaneService.BindButton(LocationButton, RightPaneKind.Location);
+        RightPaneService.BindButton(ItemButton, RightPaneKind.Item);
     }
 
     private void HamburgerButton_Click(object sender, RoutedEventArgs e)

--- a/WordForge/menus/topmenu/ItemBibleMenu.xaml
+++ b/WordForge/menus/topmenu/ItemBibleMenu.xaml
@@ -37,11 +37,11 @@
             </Border>
 
             <!-- Timeline button -->
-            <Button Grid.Column="4" Height="52" Background="#FFE5E7EB" BorderBrush="#FF9CA3AF"
+            <Button x:Name="TimelineButton" Grid.Column="4" Height="52" Background="#FFE5E7EB" BorderBrush="#FF9CA3AF"
                     Foreground="#FF111111" FontWeight="Bold" Cursor="Hand" Content="Timeline"/>
 
             <!-- Outline button -->
-            <Button Grid.Column="6" Height="52" Background="#FFE5E7EB" BorderBrush="#FF9CA3AF"
+            <Button x:Name="OutlineButton" Grid.Column="6" Height="52" Background="#FFE5E7EB" BorderBrush="#FF9CA3AF"
                     Foreground="#FF111111" FontWeight="Bold" Cursor="Hand" Content="Outline"/>
 
             <!-- Bibles group -->
@@ -54,10 +54,10 @@
                     </Grid.RowDefinitions>
                     <TextBlock Text="Bibles" Foreground="#FFE5E7EB" FontWeight="Bold" HorizontalAlignment="Center"/>
                     <StackPanel Grid.Row="2" Orientation="Horizontal" HorizontalAlignment="Center">
-                        <Button Width="90" Height="36" Margin="0,0,8,0"
+                        <Button x:Name="CharacterButton" Width="90" Height="36" Margin="0,0,8,0"
                                 Background="#FFE5E7EB" BorderBrush="#FF9CA3AF"
                                 Foreground="#FF111111" FontWeight="SemiBold" Content="Character"/>
-                        <Button Width="90" Height="36"
+                        <Button x:Name="LocationButton" Width="90" Height="36"
                                 Background="#FFE5E7EB" BorderBrush="#FF9CA3AF"
                                 Foreground="#FF111111" FontWeight="SemiBold" Content="Location"/>
                     </StackPanel>

--- a/WordForge/menus/topmenu/ItemBibleMenu.xaml.cs
+++ b/WordForge/menus/topmenu/ItemBibleMenu.xaml.cs
@@ -1,5 +1,6 @@
 using System.Windows;
 using System.Windows.Controls;
+using WordForge;
 
 namespace WordForge.Menus.TopMenu;
 
@@ -9,6 +10,10 @@ public partial class ItemBibleMenu : UserControl
     {
         InitializeComponent();
         HamburgerButton.Click += HamburgerButton_Click;
+        RightPaneService.BindButton(TimelineButton, RightPaneKind.Timeline);
+        RightPaneService.BindButton(OutlineButton, RightPaneKind.Outline);
+        RightPaneService.BindButton(CharacterButton, RightPaneKind.Character);
+        RightPaneService.BindButton(LocationButton, RightPaneKind.Location);
     }
 
     private void HamburgerButton_Click(object sender, RoutedEventArgs e)

--- a/WordForge/menus/topmenu/LocationBibleMenu.xaml
+++ b/WordForge/menus/topmenu/LocationBibleMenu.xaml
@@ -37,11 +37,11 @@
             </Border>
 
             <!-- Timeline button -->
-            <Button Grid.Column="4" Height="52" Background="#FFE5E7EB" BorderBrush="#FF9CA3AF"
+            <Button x:Name="TimelineButton" Grid.Column="4" Height="52" Background="#FFE5E7EB" BorderBrush="#FF9CA3AF"
                     Foreground="#FF111111" FontWeight="Bold" Cursor="Hand" Content="Timeline"/>
 
             <!-- Outline button -->
-            <Button Grid.Column="6" Height="52" Background="#FFE5E7EB" BorderBrush="#FF9CA3AF"
+            <Button x:Name="OutlineButton" Grid.Column="6" Height="52" Background="#FFE5E7EB" BorderBrush="#FF9CA3AF"
                     Foreground="#FF111111" FontWeight="Bold" Cursor="Hand" Content="Outline"/>
 
             <!-- Bibles group -->
@@ -54,10 +54,10 @@
                     </Grid.RowDefinitions>
                     <TextBlock Text="Bibles" Foreground="#FFE5E7EB" FontWeight="Bold" HorizontalAlignment="Center"/>
                     <StackPanel Grid.Row="2" Orientation="Horizontal" HorizontalAlignment="Center">
-                        <Button Width="90" Height="36" Margin="0,0,8,0"
+                        <Button x:Name="CharacterButton" Width="90" Height="36" Margin="0,0,8,0"
                                 Background="#FFE5E7EB" BorderBrush="#FF9CA3AF"
                                 Foreground="#FF111111" FontWeight="SemiBold" Content="Character"/>
-                        <Button Width="90" Height="36"
+                        <Button x:Name="ItemButton" Width="90" Height="36"
                                 Background="#FFE5E7EB" BorderBrush="#FF9CA3AF"
                                 Foreground="#FF111111" FontWeight="SemiBold" Content="Item"/>
                     </StackPanel>

--- a/WordForge/menus/topmenu/LocationBibleMenu.xaml.cs
+++ b/WordForge/menus/topmenu/LocationBibleMenu.xaml.cs
@@ -1,5 +1,6 @@
 using System.Windows;
 using System.Windows.Controls;
+using WordForge;
 
 namespace WordForge.Menus.TopMenu;
 
@@ -9,6 +10,10 @@ public partial class LocationBibleMenu : UserControl
     {
         InitializeComponent();
         HamburgerButton.Click += HamburgerButton_Click;
+        RightPaneService.BindButton(TimelineButton, RightPaneKind.Timeline);
+        RightPaneService.BindButton(OutlineButton, RightPaneKind.Outline);
+        RightPaneService.BindButton(CharacterButton, RightPaneKind.Character);
+        RightPaneService.BindButton(ItemButton, RightPaneKind.Item);
     }
 
     private void HamburgerButton_Click(object sender, RoutedEventArgs e)

--- a/WordForge/menus/topmenu/OutlineMenu.xaml
+++ b/WordForge/menus/topmenu/OutlineMenu.xaml
@@ -34,7 +34,7 @@
             </Border>
 
             <!-- Timeline button -->
-            <Button Grid.Column="4" Height="52" Background="#FFE5E7EB" BorderBrush="#FF9CA3AF"
+            <Button x:Name="TimelineButton" Grid.Column="4" Height="52" Background="#FFE5E7EB" BorderBrush="#FF9CA3AF"
                     Foreground="#FF111111" FontWeight="Bold" Cursor="Hand" Content="Timeline"/>
 
             <!-- Bibles group -->
@@ -47,13 +47,13 @@
                     </Grid.RowDefinitions>
                     <TextBlock Text="Bibles" Foreground="#FFE5E7EB" FontWeight="Bold" HorizontalAlignment="Center"/>
                     <StackPanel Grid.Row="2" Orientation="Horizontal" HorizontalAlignment="Center">
-                        <Button Width="90" Height="36" Margin="0,0,8,0"
+                        <Button x:Name="CharacterButton" Width="90" Height="36" Margin="0,0,8,0"
                                 Background="#FFE5E7EB" BorderBrush="#FF9CA3AF"
                                 Foreground="#FF111111" FontWeight="SemiBold" Content="Character"/>
-                        <Button Width="90" Height="36" Margin="0,0,8,0"
+                        <Button x:Name="LocationButton" Width="90" Height="36" Margin="0,0,8,0"
                                 Background="#FFE5E7EB" BorderBrush="#FF9CA3AF"
                                 Foreground="#FF111111" FontWeight="SemiBold" Content="Location"/>
-                        <Button Width="90" Height="36"
+                        <Button x:Name="ItemButton" Width="90" Height="36"
                                 Background="#FFE5E7EB" BorderBrush="#FF9CA3AF"
                                 Foreground="#FF111111" FontWeight="SemiBold" Content="Item"/>
                     </StackPanel>

--- a/WordForge/menus/topmenu/OutlineMenu.xaml.cs
+++ b/WordForge/menus/topmenu/OutlineMenu.xaml.cs
@@ -1,5 +1,6 @@
 using System.Windows;
 using System.Windows.Controls;
+using WordForge;
 
 namespace WordForge.Menus.TopMenu;
 
@@ -9,6 +10,10 @@ public partial class OutlineMenu : UserControl
     {
         InitializeComponent();
         HamburgerButton.Click += HamburgerButton_Click;
+        RightPaneService.BindButton(TimelineButton, RightPaneKind.Timeline);
+        RightPaneService.BindButton(CharacterButton, RightPaneKind.Character);
+        RightPaneService.BindButton(LocationButton, RightPaneKind.Location);
+        RightPaneService.BindButton(ItemButton, RightPaneKind.Item);
     }
 
     private void HamburgerButton_Click(object sender, RoutedEventArgs e)

--- a/WordForge/menus/topmenu/TimelineMenu.xaml
+++ b/WordForge/menus/topmenu/TimelineMenu.xaml
@@ -34,7 +34,7 @@
             </Border>
 
             <!-- Outline button -->
-            <Button Grid.Column="4" Height="52" Background="#FFE5E7EB" BorderBrush="#FF9CA3AF"
+            <Button x:Name="OutlineButton" Grid.Column="4" Height="52" Background="#FFE5E7EB" BorderBrush="#FF9CA3AF"
                     Foreground="#FF111111" FontWeight="Bold" Cursor="Hand" Content="Outline"/>
 
             <!-- Bibles group -->
@@ -47,13 +47,13 @@
                     </Grid.RowDefinitions>
                     <TextBlock Text="Bibles" Foreground="#FFE5E7EB" FontWeight="Bold" HorizontalAlignment="Center"/>
                     <StackPanel Grid.Row="2" Orientation="Horizontal" HorizontalAlignment="Center">
-                        <Button Width="90" Height="36" Margin="0,0,8,0"
+                        <Button x:Name="CharacterButton" Width="90" Height="36" Margin="0,0,8,0"
                                 Background="#FFE5E7EB" BorderBrush="#FF9CA3AF"
                                 Foreground="#FF111111" FontWeight="SemiBold" Content="Character"/>
-                        <Button Width="90" Height="36" Margin="0,0,8,0"
+                        <Button x:Name="LocationButton" Width="90" Height="36" Margin="0,0,8,0"
                                 Background="#FFE5E7EB" BorderBrush="#FF9CA3AF"
                                 Foreground="#FF111111" FontWeight="SemiBold" Content="Location"/>
-                        <Button Width="90" Height="36"
+                        <Button x:Name="ItemButton" Width="90" Height="36"
                                 Background="#FFE5E7EB" BorderBrush="#FF9CA3AF"
                                 Foreground="#FF111111" FontWeight="SemiBold" Content="Item"/>
                     </StackPanel>

--- a/WordForge/menus/topmenu/TimelineMenu.xaml.cs
+++ b/WordForge/menus/topmenu/TimelineMenu.xaml.cs
@@ -1,5 +1,6 @@
 using System.Windows;
 using System.Windows.Controls;
+using WordForge;
 
 namespace WordForge.Menus.TopMenu;
 
@@ -9,6 +10,10 @@ public partial class TimelineMenu : UserControl
     {
         InitializeComponent();
         HamburgerButton.Click += HamburgerButton_Click;
+        RightPaneService.BindButton(OutlineButton, RightPaneKind.Outline);
+        RightPaneService.BindButton(CharacterButton, RightPaneKind.Character);
+        RightPaneService.BindButton(LocationButton, RightPaneKind.Location);
+        RightPaneService.BindButton(ItemButton, RightPaneKind.Item);
     }
 
     private void HamburgerButton_Click(object sender, RoutedEventArgs e)

--- a/WordForge/menus/topmenu/TranscriptMenu.xaml
+++ b/WordForge/menus/topmenu/TranscriptMenu.xaml
@@ -37,11 +37,11 @@
             </Border>
 
             <!-- Timeline button -->
-            <Button Grid.Column="4" Height="52" Background="#FFE5E7EB" BorderBrush="#FF9CA3AF"
+            <Button x:Name="TimelineButton" Grid.Column="4" Height="52" Background="#FFE5E7EB" BorderBrush="#FF9CA3AF"
                     Foreground="#FF111111" FontWeight="Bold" Cursor="Hand" Content="Timeline"/>
 
             <!-- Outline button -->
-            <Button Grid.Column="6" Height="52" Background="#FFE5E7EB" BorderBrush="#FF9CA3AF"
+            <Button x:Name="OutlineButton" Grid.Column="6" Height="52" Background="#FFE5E7EB" BorderBrush="#FF9CA3AF"
                     Foreground="#FF111111" FontWeight="Bold" Cursor="Hand" Content="Outline"/>
 
             <!-- Bibles group -->
@@ -54,13 +54,13 @@
                     </Grid.RowDefinitions>
                     <TextBlock Text="Bibles" Foreground="#FFE5E7EB" FontWeight="Bold" HorizontalAlignment="Center"/>
                     <StackPanel Grid.Row="2" Orientation="Horizontal" HorizontalAlignment="Center">
-                        <Button Width="90" Height="36" Margin="0,0,8,0"
+                        <Button x:Name="CharacterButton" Width="90" Height="36" Margin="0,0,8,0"
                                 Background="#FFE5E7EB" BorderBrush="#FF9CA3AF"
                                 Foreground="#FF111111" FontWeight="SemiBold" Content="Character"/>
-                        <Button Width="90" Height="36" Margin="0,0,8,0"
+                        <Button x:Name="LocationButton" Width="90" Height="36" Margin="0,0,8,0"
                                 Background="#FFE5E7EB" BorderBrush="#FF9CA3AF"
                                 Foreground="#FF111111" FontWeight="SemiBold" Content="Location"/>
-                        <Button Width="90" Height="36"
+                        <Button x:Name="ItemButton" Width="90" Height="36"
                                 Background="#FFE5E7EB" BorderBrush="#FF9CA3AF"
                                 Foreground="#FF111111" FontWeight="SemiBold" Content="Item"/>
                     </StackPanel>

--- a/WordForge/menus/topmenu/TranscriptMenu.xaml.cs
+++ b/WordForge/menus/topmenu/TranscriptMenu.xaml.cs
@@ -1,5 +1,6 @@
 using System.Windows;
 using System.Windows.Controls;
+using WordForge;
 
 namespace WordForge.Menus.TopMenu;
 
@@ -9,6 +10,11 @@ public partial class TranscriptMenu : UserControl
     {
         InitializeComponent();
         HamburgerButton.Click += HamburgerButton_Click;
+        RightPaneService.BindButton(TimelineButton, RightPaneKind.Timeline);
+        RightPaneService.BindButton(OutlineButton, RightPaneKind.Outline);
+        RightPaneService.BindButton(CharacterButton, RightPaneKind.Character);
+        RightPaneService.BindButton(LocationButton, RightPaneKind.Location);
+        RightPaneService.BindButton(ItemButton, RightPaneKind.Item);
     }
 
     private void HamburgerButton_Click(object sender, RoutedEventArgs e)

--- a/WordForge/panes/CharacterBiblePane.xaml
+++ b/WordForge/panes/CharacterBiblePane.xaml
@@ -1,0 +1,8 @@
+<UserControl x:Class="WordForge.Panes.CharacterBiblePane"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <Grid>
+        <TextBlock Text="Character Bible Pane" Foreground="#FFE5E7EB" FontWeight="Bold"
+                   HorizontalAlignment="Center" VerticalAlignment="Center"/>
+    </Grid>
+</UserControl>

--- a/WordForge/panes/CharacterBiblePane.xaml.cs
+++ b/WordForge/panes/CharacterBiblePane.xaml.cs
@@ -1,0 +1,11 @@
+using System.Windows.Controls;
+
+namespace WordForge.Panes;
+
+public partial class CharacterBiblePane : UserControl
+{
+    public CharacterBiblePane()
+    {
+        InitializeComponent();
+    }
+}

--- a/WordForge/panes/ItemBiblePane.xaml
+++ b/WordForge/panes/ItemBiblePane.xaml
@@ -1,0 +1,8 @@
+<UserControl x:Class="WordForge.Panes.ItemBiblePane"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <Grid>
+        <TextBlock Text="Item Bible Pane" Foreground="#FFE5E7EB" FontWeight="Bold"
+                   HorizontalAlignment="Center" VerticalAlignment="Center"/>
+    </Grid>
+</UserControl>

--- a/WordForge/panes/ItemBiblePane.xaml.cs
+++ b/WordForge/panes/ItemBiblePane.xaml.cs
@@ -1,0 +1,11 @@
+using System.Windows.Controls;
+
+namespace WordForge.Panes;
+
+public partial class ItemBiblePane : UserControl
+{
+    public ItemBiblePane()
+    {
+        InitializeComponent();
+    }
+}

--- a/WordForge/panes/LocationBiblePane.xaml
+++ b/WordForge/panes/LocationBiblePane.xaml
@@ -1,0 +1,8 @@
+<UserControl x:Class="WordForge.Panes.LocationBiblePane"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <Grid>
+        <TextBlock Text="Location Bible Pane" Foreground="#FFE5E7EB" FontWeight="Bold"
+                   HorizontalAlignment="Center" VerticalAlignment="Center"/>
+    </Grid>
+</UserControl>

--- a/WordForge/panes/LocationBiblePane.xaml.cs
+++ b/WordForge/panes/LocationBiblePane.xaml.cs
@@ -1,0 +1,11 @@
+using System.Windows.Controls;
+
+namespace WordForge.Panes;
+
+public partial class LocationBiblePane : UserControl
+{
+    public LocationBiblePane()
+    {
+        InitializeComponent();
+    }
+}

--- a/WordForge/panes/OutlinePane.xaml
+++ b/WordForge/panes/OutlinePane.xaml
@@ -1,0 +1,8 @@
+<UserControl x:Class="WordForge.Panes.OutlinePane"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <Grid>
+        <TextBlock Text="Outline Pane" Foreground="#FFE5E7EB" FontWeight="Bold"
+                   HorizontalAlignment="Center" VerticalAlignment="Center"/>
+    </Grid>
+</UserControl>

--- a/WordForge/panes/OutlinePane.xaml.cs
+++ b/WordForge/panes/OutlinePane.xaml.cs
@@ -1,0 +1,11 @@
+using System.Windows.Controls;
+
+namespace WordForge.Panes;
+
+public partial class OutlinePane : UserControl
+{
+    public OutlinePane()
+    {
+        InitializeComponent();
+    }
+}

--- a/WordForge/panes/TimelinePane.xaml
+++ b/WordForge/panes/TimelinePane.xaml
@@ -1,0 +1,8 @@
+<UserControl x:Class="WordForge.Panes.TimelinePane"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <Grid>
+        <TextBlock Text="Timeline Pane" Foreground="#FFE5E7EB" FontWeight="Bold" 
+                   HorizontalAlignment="Center" VerticalAlignment="Center"/>
+    </Grid>
+</UserControl>

--- a/WordForge/panes/TimelinePane.xaml.cs
+++ b/WordForge/panes/TimelinePane.xaml.cs
@@ -1,0 +1,11 @@
+using System.Windows.Controls;
+
+namespace WordForge.Panes;
+
+public partial class TimelinePane : UserControl
+{
+    public TimelinePane()
+    {
+        InitializeComponent();
+    }
+}


### PR DESCRIPTION
## Summary
- add placeholder right-pane views for timeline, outline, character, location and item bibles
- introduce RightPaneService and host to swap panes and highlight active buttons
- wire all top menus to request pane changes via shared service and default to timeline on startup

## Testing
- `dotnet build` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68a521ee658483309da51e84d6527b6d