### PR TITLE
0.0.6 - Menu Transitions Wired

### DIFF
--- a/WordForge/MainWindow.xaml
+++ b/WordForge/MainWindow.xaml
@@ -18,7 +18,9 @@
         </Grid.RowDefinitions>
 
         <!-- ===== TOP BAR ===== -->
-        <ContentControl x:Name="TopMenuContent" Grid.Row="0"/>
+        <Grid x:Name="TopMenuHost" Grid.Row="0" ClipToBounds="True">
+            <ContentControl x:Name="TopMenuContent"/>
+        </Grid>
 
         <!-- ===== MAIN AREA (left rail + center + right pane ~25%) ===== -->
         <Grid Grid.Row="1">
@@ -35,7 +37,7 @@
             <menus:LeftMenu Grid.Column="0"/>
 
             <!-- Center editor surface -->
-            <Grid Grid.Column="1" Background="#FF1A1B1E" Margin="12,0,12,0">
+            <Grid x:Name="CenterHost" Grid.Column="1" Background="#FF1A1B1E" Margin="12,0,12,0" ClipToBounds="True">
                 <Grid.RowDefinitions>
                     <RowDefinition Height="28"/>
                     <!-- Section title -->
@@ -61,8 +63,8 @@
             </Grid>
 
             <!-- Right pane (~25%) -->
-            <Border Grid.Column="2" Margin="0,0,12,0" Background="#FF232529"
-                    BorderBrush="#FF3B3F45" BorderThickness="1" CornerRadius="6">
+            <Border x:Name="RightPaneHost" Grid.Column="2" Margin="0,0,12,0" Background="#FF232529"
+                    BorderBrush="#FF3B3F45" BorderThickness="1" CornerRadius="6" ClipToBounds="True">
                 <ContentControl x:Name="RightPaneContent"/>
             </Border>
         </Grid>

--- a/WordForge/MainWindow.xaml.cs
+++ b/WordForge/MainWindow.xaml.cs
@@ -17,10 +17,15 @@ namespace WordForge
     /// </summary>
     public partial class MainWindow : Window
     {
+        public Grid TopMenuHostElement => TopMenuHost;
+        public Grid CenterHostElement => CenterHost;
+        public Border RightPaneHostElement => RightPaneHost;
+
         public MainWindow()
         {
             InitializeComponent();
             RightPaneService.Host = RightPaneContent;
+            RightPaneService.Container = RightPaneHost;
             TopMenuContent.Content = new TranscriptMenu();
             RightPaneService.Show(RightPaneKind.Timeline);
         }

--- a/WordForge/PropertiesWindow.xaml
+++ b/WordForge/PropertiesWindow.xaml
@@ -1,0 +1,34 @@
+<Window x:Class="WordForge.PropertiesWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Properties" SizeToContent="WidthAndHeight"
+        WindowStartupLocation="CenterOwner" ResizeMode="NoResize"
+        Background="#FF1A1B1E" FontFamily="Segoe UI">
+    <Window.Resources>
+        <Style x:Key="ToggleSwitchStyle" TargetType="ToggleButton">
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="ToggleButton">
+                        <Grid Width="50" Height="24">
+                            <Border x:Name="SwitchBorder" Background="#FF9CA3AF" CornerRadius="12"/>
+                            <Border x:Name="Knob" Width="20" Height="20" Background="White" CornerRadius="10" Margin="2" HorizontalAlignment="Left"/>
+                        </Grid>
+                        <ControlTemplate.Triggers>
+                            <Trigger Property="IsChecked" Value="True">
+                                <Setter TargetName="SwitchBorder" Property="Background" Value="#FF30D158"/>
+                                <Setter TargetName="Knob" Property="HorizontalAlignment" Value="Right"/>
+                            </Trigger>
+                        </ControlTemplate.Triggers>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
+    </Window.Resources>
+    <StackPanel Margin="20">
+        <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+            <TextBlock Text="Transitions:" Foreground="#FFE5E7EB" VerticalAlignment="Center" Margin="0,0,8,0"/>
+            <ToggleButton x:Name="TransitionsToggle" Style="{StaticResource ToggleSwitchStyle}" Width="50" Height="24"/>
+            <TextBlock x:Name="ToggleStateText" Foreground="#FFE5E7EB" VerticalAlignment="Center" Margin="8,0,0,0"/>
+        </StackPanel>
+    </StackPanel>
+</Window>

--- a/WordForge/PropertiesWindow.xaml.cs
+++ b/WordForge/PropertiesWindow.xaml.cs
@@ -1,0 +1,22 @@
+using System.Windows;
+
+namespace WordForge;
+
+public partial class PropertiesWindow : Window
+{
+    public PropertiesWindow()
+    {
+        InitializeComponent();
+        TransitionsToggle.IsChecked = TransitionService.TransitionsEnabled;
+        ToggleStateText.Text = TransitionService.TransitionsEnabled ? "On" : "Off";
+        TransitionsToggle.Checked += ToggleChanged;
+        TransitionsToggle.Unchecked += ToggleChanged;
+    }
+
+    private void ToggleChanged(object? sender, RoutedEventArgs e)
+    {
+        bool enabled = TransitionsToggle.IsChecked == true;
+        TransitionService.TransitionsEnabled = enabled;
+        ToggleStateText.Text = enabled ? "On" : "Off";
+    }
+}

--- a/WordForge/RightPaneService.cs
+++ b/WordForge/RightPaneService.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Media;
 using WordForge.Panes;
@@ -17,6 +18,7 @@ public enum RightPaneKind
 public static class RightPaneService
 {
     public static ContentControl? Host { get; set; }
+    public static FrameworkElement? Container { get; set; }
 
     public static RightPaneKind CurrentPane { get; private set; } = RightPaneKind.Timeline;
 
@@ -24,20 +26,32 @@ public static class RightPaneService
 
     public static void Show(RightPaneKind kind)
     {
-        if (Host != null)
+        void Update()
         {
-            Host.Content = kind switch
+            if (Host != null)
             {
-                RightPaneKind.Timeline => new TimelinePane(),
-                RightPaneKind.Outline => new OutlinePane(),
-                RightPaneKind.Character => new CharacterBiblePane(),
-                RightPaneKind.Location => new LocationBiblePane(),
-                RightPaneKind.Item => new ItemBiblePane(),
-                _ => new TimelinePane()
-            };
+                Host.Content = kind switch
+                {
+                    RightPaneKind.Timeline => new TimelinePane(),
+                    RightPaneKind.Outline => new OutlinePane(),
+                    RightPaneKind.Character => new CharacterBiblePane(),
+                    RightPaneKind.Location => new LocationBiblePane(),
+                    RightPaneKind.Item => new ItemBiblePane(),
+                    _ => new TimelinePane()
+                };
+            }
+            CurrentPane = kind;
+            PaneChanged?.Invoke(kind);
         }
-        CurrentPane = kind;
-        PaneChanged?.Invoke(kind);
+
+        if (Container != null && Container.RenderSize.Width > 0)
+        {
+            TransitionService.SlideHorizontal(Container, Container.RenderSize.Width, Update);
+        }
+        else
+        {
+            Update();
+        }
     }
 
     public static void BindButton(Button button, RightPaneKind kind)

--- a/WordForge/animations/TransitionService.cs
+++ b/WordForge/animations/TransitionService.cs
@@ -1,0 +1,99 @@
+using System;
+using System.Windows;
+using System.Windows.Media;
+using System.Windows.Media.Animation;
+
+namespace WordForge;
+
+public static class TransitionService
+{
+    public static bool TransitionsEnabled { get; set; } = true;
+
+    private static TranslateTransform GetTransform(UIElement element)
+    {
+        if (element.RenderTransform is TranslateTransform t)
+            return t;
+        t = new TranslateTransform();
+        element.RenderTransform = t;
+        return t;
+    }
+
+    public static void SlideVertical(UIElement element)
+    {
+        if (!TransitionsEnabled)
+        {
+            ResetTransform(element);
+            return;
+        }
+
+        var transform = GetTransform(element);
+        transform.BeginAnimation(TranslateTransform.YProperty, null);
+        transform.Y = 0;
+        element.IsHitTestVisible = false;
+
+        double offset = element.RenderSize.Height;
+        var retract = new DoubleAnimation(-offset, TimeSpan.FromMilliseconds(180))
+        {
+            EasingFunction = new CubicEase { EasingMode = EasingMode.EaseIn }
+        };
+        retract.Completed += (_, __) =>
+        {
+            var expand = new DoubleAnimation(0, TimeSpan.FromMilliseconds(220))
+            {
+                EasingFunction = new CubicEase { EasingMode = EasingMode.EaseOut }
+            };
+            expand.Completed += (_, __2) =>
+            {
+                element.IsHitTestVisible = true;
+                transform.Y = 0;
+            };
+            transform.BeginAnimation(TranslateTransform.YProperty, expand, HandoffBehavior.SnapshotAndReplace);
+        };
+        transform.BeginAnimation(TranslateTransform.YProperty, retract, HandoffBehavior.SnapshotAndReplace);
+    }
+
+    public static void SlideHorizontal(UIElement element, double offset, Action? midwayAction = null)
+    {
+        if (!TransitionsEnabled)
+        {
+            midwayAction?.Invoke();
+            ResetTransform(element);
+            return;
+        }
+
+        var transform = GetTransform(element);
+        transform.BeginAnimation(TranslateTransform.XProperty, null);
+        transform.X = 0;
+        element.IsHitTestVisible = false;
+
+        var retract = new DoubleAnimation(offset, TimeSpan.FromMilliseconds(180))
+        {
+            EasingFunction = new CubicEase { EasingMode = EasingMode.EaseIn }
+        };
+        retract.Completed += (_, __) =>
+        {
+            midwayAction?.Invoke();
+            var expand = new DoubleAnimation(0, TimeSpan.FromMilliseconds(220))
+            {
+                EasingFunction = new CubicEase { EasingMode = EasingMode.EaseOut }
+            };
+            expand.Completed += (_, __2) =>
+            {
+                element.IsHitTestVisible = true;
+                transform.X = 0;
+            };
+            transform.BeginAnimation(TranslateTransform.XProperty, expand, HandoffBehavior.SnapshotAndReplace);
+        };
+        transform.BeginAnimation(TranslateTransform.XProperty, retract, HandoffBehavior.SnapshotAndReplace);
+    }
+
+    public static void ResetTransform(UIElement element)
+    {
+        var transform = GetTransform(element);
+        transform.BeginAnimation(TranslateTransform.XProperty, null);
+        transform.BeginAnimation(TranslateTransform.YProperty, null);
+        transform.X = 0;
+        transform.Y = 0;
+        element.IsHitTestVisible = true;
+    }
+}

--- a/WordForge/menus/FileMenu.xaml
+++ b/WordForge/menus/FileMenu.xaml
@@ -9,8 +9,7 @@
             <!-- TODO: Wire up Save -->
             <Button Content="Load" Margin="0,0,0,4" Background="#FFE5E7EB" BorderBrush="#FF9CA3AF" Foreground="#FF111111" />
             <!-- TODO: Wire up Load -->
-            <Button Content="Properties" Margin="0,0,0,4" Background="#FFE5E7EB" BorderBrush="#FF9CA3AF" Foreground="#FF111111" />
-            <!-- TODO: Wire up Properties -->
+            <Button Content="Properties" Margin="0,0,0,4" Background="#FFE5E7EB" BorderBrush="#FF9CA3AF" Foreground="#FF111111" Click="Properties_Click"/>
             <Button Content="Print" Margin="0,0,0,4" Background="#FFE5E7EB" BorderBrush="#FF9CA3AF" Foreground="#FF111111" />
             <!-- TODO: Wire up Print -->
             <Button Content="Exit" Background="#FFE5E7EB" BorderBrush="#FF9CA3AF" Foreground="#FF111111" Click="Exit_Click" />

--- a/WordForge/menus/FileMenu.xaml.cs
+++ b/WordForge/menus/FileMenu.xaml.cs
@@ -1,5 +1,6 @@
 using System.Windows;
 using System.Windows.Controls;
+using WordForge;
 
 namespace WordForge.Menus;
 
@@ -8,6 +9,12 @@ public partial class FileMenu : UserControl
     public FileMenu()
     {
         InitializeComponent();
+    }
+
+    private void Properties_Click(object sender, RoutedEventArgs e)
+    {
+        var window = new PropertiesWindow { Owner = Application.Current.MainWindow };
+        window.ShowDialog();
     }
 
     private void Exit_Click(object sender, RoutedEventArgs e)

--- a/WordForge/menus/LeftMenu.xaml.cs
+++ b/WordForge/menus/LeftMenu.xaml.cs
@@ -1,6 +1,7 @@
 using System.Windows;
 using System.Windows.Controls;
 using WordForge.Menus.TopMenu;
+using WordForge;
 
 namespace WordForge.Menus;
 
@@ -11,33 +12,46 @@ public partial class LeftMenu : UserControl
         InitializeComponent();
     }
 
+    private static void AnimateMenus()
+    {
+        var main = (MainWindow)Application.Current.MainWindow;
+        TransitionService.SlideVertical(main.TopMenuHostElement);
+        TransitionService.SlideVertical(main.CenterHostElement);
+    }
+
     private void TranscriptButton_Click(object sender, RoutedEventArgs e)
     {
         ((MainWindow)Application.Current.MainWindow).TopMenuContent.Content = new TranscriptMenu();
+        AnimateMenus();
     }
 
     private void TimelineButton_Click(object sender, RoutedEventArgs e)
     {
         ((MainWindow)Application.Current.MainWindow).TopMenuContent.Content = new TimelineMenu();
+        AnimateMenus();
     }
 
     private void OutlineButton_Click(object sender, RoutedEventArgs e)
     {
         ((MainWindow)Application.Current.MainWindow).TopMenuContent.Content = new OutlineMenu();
+        AnimateMenus();
     }
 
     private void CharacterBibleButton_Click(object sender, RoutedEventArgs e)
     {
         ((MainWindow)Application.Current.MainWindow).TopMenuContent.Content = new CharacterBibleMenu();
+        AnimateMenus();
     }
 
     private void LocationBibleButton_Click(object sender, RoutedEventArgs e)
     {
         ((MainWindow)Application.Current.MainWindow).TopMenuContent.Content = new LocationBibleMenu();
+        AnimateMenus();
     }
 
     private void ItemBibleButton_Click(object sender, RoutedEventArgs e)
     {
         ((MainWindow)Application.Current.MainWindow).TopMenuContent.Content = new ItemBibleMenu();
+        AnimateMenus();
     }
 }


### PR DESCRIPTION
## Summary
- add centralized TransitionService with cubic easing animations
- animate top menu/center panes on left-nav clicks and right pane on top menu clicks
- introduce Properties dialog with session toggle for transitions

## Testing
- `dotnet build` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68a5250842e88330af1a1260fd57d119