### PR TITLE
Add project file dialog and slow pane transitions

### DIFF
--- a/WordForge/NewProjectWindow.xaml
+++ b/WordForge/NewProjectWindow.xaml
@@ -1,0 +1,25 @@
+<Window x:Class="WordForge.NewProjectWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="New Project" SizeToContent="WidthAndHeight"
+        WindowStartupLocation="CenterOwner" ResizeMode="NoResize"
+        Background="#FF1A1B1E" FontFamily="Segoe UI">
+    <StackPanel Margin="20" Width="320">
+        <StackPanel Orientation="Horizontal" Margin="0,0,0,10">
+            <TextBlock Text="Title:" Width="60" Foreground="#FFE5E7EB" VerticalAlignment="Center"/>
+            <TextBox x:Name="TitleBox" Width="220"/>
+        </StackPanel>
+        <StackPanel Orientation="Horizontal" Margin="0,0,0,10">
+            <TextBlock Text="Author:" Width="60" Foreground="#FFE5E7EB" VerticalAlignment="Center"/>
+            <TextBox x:Name="AuthorBox" Width="220"/>
+        </StackPanel>
+        <StackPanel Orientation="Horizontal" Margin="0,0,0,20">
+            <TextBlock Text="Genre:" Width="60" Foreground="#FFE5E7EB" VerticalAlignment="Center"/>
+            <ComboBox x:Name="GenreBox" Width="220"/>
+        </StackPanel>
+        <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
+            <Button Width="75" Margin="0,0,8,0" Content="OK" Click="Ok_Click"/>
+            <Button Width="75" Content="Cancel" Click="Cancel_Click"/>
+        </StackPanel>
+    </StackPanel>
+</Window>

--- a/WordForge/NewProjectWindow.xaml.cs
+++ b/WordForge/NewProjectWindow.xaml.cs
@@ -1,0 +1,32 @@
+using System.Windows;
+
+namespace WordForge;
+
+public partial class NewProjectWindow : Window
+{
+    public string ProjectTitle => TitleBox.Text.Trim();
+    public string ProjectAuthor => AuthorBox.Text.Trim();
+    public string ProjectGenre => GenreBox.SelectedItem?.ToString() ?? "";
+
+    public NewProjectWindow()
+    {
+        InitializeComponent();
+        GenreBox.ItemsSource = new[] { "Fantasy", "Sci-Fi", "Mystery", "Romance", "Other" };
+        GenreBox.SelectedIndex = 0;
+    }
+
+    private void Ok_Click(object sender, RoutedEventArgs e)
+    {
+        if (string.IsNullOrWhiteSpace(ProjectTitle))
+        {
+            MessageBox.Show(this, "Title is required.", "Validation", MessageBoxButton.OK, MessageBoxImage.Warning);
+            return;
+        }
+        DialogResult = true;
+    }
+
+    private void Cancel_Click(object sender, RoutedEventArgs e)
+    {
+        DialogResult = false;
+    }
+}

--- a/WordForge/ProjectService.cs
+++ b/WordForge/ProjectService.cs
@@ -1,0 +1,117 @@
+using System;
+using System.IO;
+using System.Text.Json;
+using System.Windows;
+using Microsoft.Win32;
+
+namespace WordForge;
+
+public record Project
+{
+    public string Title { get; set; } = "";
+    public string Author { get; set; } = "";
+    public string Genre { get; set; } = "";
+    public DateTime Created { get; set; }
+        = DateTime.Now;
+    public DateTime Saved { get; set; }
+        = DateTime.Now;
+}
+
+public static class ProjectService
+{
+    public static Project CurrentProject { get; private set; } = new Project
+    {
+        Title = "New Project",
+        Created = DateTime.Now,
+        Saved = DateTime.Now
+    };
+
+    public static string? CurrentPath { get; private set; }
+        = null;
+
+    public static void CreateNew(Project project)
+    {
+        var documents = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
+        var fileName = SanitizeFileName(project.Title) + ".forge";
+        var path = Path.Combine(documents, fileName);
+        project.Created = project.Saved = DateTime.Now;
+        SaveToPath(project, path);
+        SetCurrent(project, path);
+    }
+
+    public static void Save()
+    {
+        if (CurrentProject == null)
+            return;
+
+        if (CurrentPath == null)
+        {
+            var dialog = new SaveFileDialog
+            {
+                Filter = "WordForge Project (*.forge)|*.forge",
+                DefaultExt = ".forge",
+                InitialDirectory = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments),
+                FileName = SanitizeFileName(CurrentProject.Title) + ".forge"
+            };
+            if (dialog.ShowDialog() == true)
+            {
+                SaveToPath(CurrentProject, dialog.FileName);
+                CurrentPath = dialog.FileName;
+            }
+        }
+        else
+        {
+            SaveToPath(CurrentProject, CurrentPath);
+        }
+        UpdateWindowTitle();
+    }
+
+    public static void Load()
+    {
+        var dialog = new OpenFileDialog
+        {
+            Filter = "WordForge Project (*.forge)|*.forge",
+            DefaultExt = ".forge",
+            InitialDirectory = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments)
+        };
+        if (dialog.ShowDialog() == true)
+        {
+            var json = File.ReadAllText(dialog.FileName);
+            var project = JsonSerializer.Deserialize<Project>(json);
+            if (project != null)
+            {
+                SetCurrent(project, dialog.FileName);
+            }
+        }
+    }
+
+    private static void SaveToPath(Project project, string path)
+    {
+        project.Saved = DateTime.Now;
+        var json = JsonSerializer.Serialize(project, new JsonSerializerOptions { WriteIndented = true });
+        File.WriteAllText(path, json);
+    }
+
+    private static void SetCurrent(Project project, string path)
+    {
+        CurrentProject = project;
+        CurrentPath = path;
+        UpdateWindowTitle();
+    }
+
+    private static void UpdateWindowTitle()
+    {
+        if (Application.Current.MainWindow is MainWindow main && CurrentProject != null)
+        {
+            main.Title = $"WordForge - {CurrentProject.Title}";
+        }
+    }
+
+    private static string SanitizeFileName(string name)
+    {
+        foreach (var c in Path.GetInvalidFileNameChars())
+            name = name.Replace(c, '_');
+        return string.IsNullOrWhiteSpace(name) ? "project" : name;
+    }
+}
+

--- a/WordForge/animations/TransitionService.cs
+++ b/WordForge/animations/TransitionService.cs
@@ -9,6 +9,8 @@ public static class TransitionService
 {
     public static bool TransitionsEnabled { get; set; } = true;
 
+    private const double DurationScale = 2.5;
+
     private static TranslateTransform GetTransform(UIElement element)
     {
         if (element.RenderTransform is TranslateTransform t)
@@ -32,13 +34,13 @@ public static class TransitionService
         element.IsHitTestVisible = false;
 
         double offset = element.RenderSize.Height;
-        var retract = new DoubleAnimation(-offset, TimeSpan.FromMilliseconds(180))
+        var retract = new DoubleAnimation(-offset, TimeSpan.FromMilliseconds(180 * DurationScale))
         {
             EasingFunction = new CubicEase { EasingMode = EasingMode.EaseIn }
         };
         retract.Completed += (_, __) =>
         {
-            var expand = new DoubleAnimation(0, TimeSpan.FromMilliseconds(220))
+            var expand = new DoubleAnimation(0, TimeSpan.FromMilliseconds(220 * DurationScale))
             {
                 EasingFunction = new CubicEase { EasingMode = EasingMode.EaseOut }
             };
@@ -66,14 +68,14 @@ public static class TransitionService
         transform.X = 0;
         element.IsHitTestVisible = false;
 
-        var retract = new DoubleAnimation(offset, TimeSpan.FromMilliseconds(180))
+        var retract = new DoubleAnimation(offset, TimeSpan.FromMilliseconds(180 * DurationScale))
         {
             EasingFunction = new CubicEase { EasingMode = EasingMode.EaseIn }
         };
         retract.Completed += (_, __) =>
         {
             midwayAction?.Invoke();
-            var expand = new DoubleAnimation(0, TimeSpan.FromMilliseconds(220))
+            var expand = new DoubleAnimation(0, TimeSpan.FromMilliseconds(220 * DurationScale))
             {
                 EasingFunction = new CubicEase { EasingMode = EasingMode.EaseOut }
             };

--- a/WordForge/menus/FileMenu.xaml
+++ b/WordForge/menus/FileMenu.xaml
@@ -3,12 +3,9 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <Border Background="#FF232529" BorderBrush="#FF3B3F45" BorderThickness="1" CornerRadius="4" Padding="10">
         <StackPanel>
-            <Button Content="New" Margin="0,0,0,4" Background="#FFE5E7EB" BorderBrush="#FF9CA3AF" Foreground="#FF111111" />
-            <!-- TODO: Wire up New -->
-            <Button Content="Save" Margin="0,0,0,4" Background="#FFE5E7EB" BorderBrush="#FF9CA3AF" Foreground="#FF111111" />
-            <!-- TODO: Wire up Save -->
-            <Button Content="Load" Margin="0,0,0,4" Background="#FFE5E7EB" BorderBrush="#FF9CA3AF" Foreground="#FF111111" />
-            <!-- TODO: Wire up Load -->
+            <Button Content="New" Margin="0,0,0,4" Background="#FFE5E7EB" BorderBrush="#FF9CA3AF" Foreground="#FF111111" Click="New_Click" />
+            <Button Content="Save" Margin="0,0,0,4" Background="#FFE5E7EB" BorderBrush="#FF9CA3AF" Foreground="#FF111111" Click="Save_Click" />
+            <Button Content="Load" Margin="0,0,0,4" Background="#FFE5E7EB" BorderBrush="#FF9CA3AF" Foreground="#FF111111" Click="Load_Click" />
             <Button Content="Properties" Margin="0,0,0,4" Background="#FFE5E7EB" BorderBrush="#FF9CA3AF" Foreground="#FF111111" Click="Properties_Click"/>
             <Button Content="Print" Margin="0,0,0,4" Background="#FFE5E7EB" BorderBrush="#FF9CA3AF" Foreground="#FF111111" />
             <!-- TODO: Wire up Print -->

--- a/WordForge/menus/FileMenu.xaml.cs
+++ b/WordForge/menus/FileMenu.xaml.cs
@@ -11,6 +11,31 @@ public partial class FileMenu : UserControl
         InitializeComponent();
     }
 
+    private void New_Click(object sender, RoutedEventArgs e)
+    {
+        var window = new NewProjectWindow { Owner = Application.Current.MainWindow };
+        if (window.ShowDialog() == true)
+        {
+            var project = new Project
+            {
+                Title = window.ProjectTitle,
+                Author = window.ProjectAuthor,
+                Genre = window.ProjectGenre
+            };
+            ProjectService.CreateNew(project);
+        }
+    }
+
+    private void Save_Click(object sender, RoutedEventArgs e)
+    {
+        ProjectService.Save();
+    }
+
+    private void Load_Click(object sender, RoutedEventArgs e)
+    {
+        ProjectService.Load();
+    }
+
     private void Properties_Click(object sender, RoutedEventArgs e)
     {
         var window = new PropertiesWindow { Owner = Application.Current.MainWindow };


### PR DESCRIPTION
## Summary
- slow pane transitions to 2.5× their previous durations
- add modal New Project dialog and project service for save/load
- wire File menu buttons for creating, saving, and loading .forge projects

## Testing
- `dotnet build -nologo -p:EnableWindowsTargeting=true`


------
https://chatgpt.com/codex/tasks/task_e_68a529137bf08330b93271c84ca93eab