### PR TITLE
Add save location field and full project properties support

### DIFF
--- a/WordForge/NewProjectWindow.xaml
+++ b/WordForge/NewProjectWindow.xaml
@@ -13,9 +13,14 @@
             <TextBlock Text="Author:" Width="60" Foreground="#FFE5E7EB" VerticalAlignment="Center"/>
             <TextBox x:Name="AuthorBox" Width="220"/>
         </StackPanel>
-        <StackPanel Orientation="Horizontal" Margin="0,0,0,20">
+        <StackPanel Orientation="Horizontal" Margin="0,0,0,10">
             <TextBlock Text="Genre:" Width="60" Foreground="#FFE5E7EB" VerticalAlignment="Center"/>
             <ComboBox x:Name="GenreBox" Width="220"/>
+        </StackPanel>
+        <StackPanel Orientation="Horizontal" Margin="0,0,0,20">
+            <TextBlock Text="Save to:" Width="60" Foreground="#FFE5E7EB" VerticalAlignment="Center"/>
+            <TextBox x:Name="LocationBox" Width="140" IsReadOnly="True"/>
+            <Button Content="Choose Folder..." Width="100" Margin="4,0,0,0" Click="ChooseFolder_Click"/>
         </StackPanel>
         <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
             <Button Width="75" Margin="0,0,8,0" Content="OK" Click="Ok_Click"/>

--- a/WordForge/NewProjectWindow.xaml.cs
+++ b/WordForge/NewProjectWindow.xaml.cs
@@ -1,4 +1,6 @@
+using System;
 using System.Windows;
+using WinForms = System.Windows.Forms;
 
 namespace WordForge;
 
@@ -7,12 +9,16 @@ public partial class NewProjectWindow : Window
     public string ProjectTitle => TitleBox.Text.Trim();
     public string ProjectAuthor => AuthorBox.Text.Trim();
     public string ProjectGenre => GenreBox.SelectedItem?.ToString() ?? "";
+    public string ProjectLocation => string.IsNullOrWhiteSpace(LocationBox.Text)
+        ? Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments)
+        : LocationBox.Text;
 
     public NewProjectWindow()
     {
         InitializeComponent();
         GenreBox.ItemsSource = new[] { "Fantasy", "Sci-Fi", "Mystery", "Romance", "Other" };
         GenreBox.SelectedIndex = 0;
+        LocationBox.Text = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
     }
 
     private void Ok_Click(object sender, RoutedEventArgs e)
@@ -28,5 +34,14 @@ public partial class NewProjectWindow : Window
     private void Cancel_Click(object sender, RoutedEventArgs e)
     {
         DialogResult = false;
+    }
+
+    private void ChooseFolder_Click(object sender, RoutedEventArgs e)
+    {
+        using var dialog = new WinForms.FolderBrowserDialog { SelectedPath = LocationBox.Text };
+        if (dialog.ShowDialog() == WinForms.DialogResult.OK)
+        {
+            LocationBox.Text = dialog.SelectedPath;
+        }
     }
 }

--- a/WordForge/ProjectService.cs
+++ b/WordForge/ProjectService.cs
@@ -29,14 +29,16 @@ public static class ProjectService
     public static string? CurrentPath { get; private set; }
         = null;
 
-    public static void CreateNew(Project project)
+    public static void CreateNew(Project project, string? directory)
     {
-        var documents = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
+        directory = string.IsNullOrWhiteSpace(directory)
+            ? Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments)
+            : directory;
+        Directory.CreateDirectory(directory);
         var fileName = SanitizeFileName(project.Title) + ".forge";
-        var path = Path.Combine(documents, fileName);
+        var path = Path.Combine(directory, fileName);
         project.Created = project.Saved = DateTime.Now;
-        SaveToPath(project, path);
-        SetCurrent(project, path);
+        SaveProject(project, path);
     }
 
     public static void Save()
@@ -55,15 +57,35 @@ public static class ProjectService
             };
             if (dialog.ShowDialog() == true)
             {
-                SaveToPath(CurrentProject, dialog.FileName);
-                CurrentPath = dialog.FileName;
+                SaveProject(CurrentProject, dialog.FileName);
             }
         }
         else
         {
-            SaveToPath(CurrentProject, CurrentPath);
+            SaveProject(CurrentProject, CurrentPath);
         }
-        UpdateWindowTitle();
+    }
+
+    public static void SaveAs()
+    {
+        if (CurrentProject == null)
+            return;
+
+        var dialog = new SaveFileDialog
+        {
+            Filter = "WordForge Project (*.forge)|*.forge",
+            DefaultExt = ".forge",
+            InitialDirectory = CurrentPath != null
+                ? Path.GetDirectoryName(CurrentPath)
+                : Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments),
+            FileName = CurrentPath != null
+                ? Path.GetFileName(CurrentPath)
+                : SanitizeFileName(CurrentProject.Title) + ".forge"
+        };
+        if (dialog.ShowDialog() == true)
+        {
+            SaveProject(CurrentProject, dialog.FileName);
+        }
     }
 
     public static void Load()
@@ -107,11 +129,19 @@ public static class ProjectService
         }
     }
 
-    private static string SanitizeFileName(string name)
+    public static string SanitizeFileName(string name)
     {
         foreach (var c in Path.GetInvalidFileNameChars())
             name = name.Replace(c, '_');
         return string.IsNullOrWhiteSpace(name) ? "project" : name;
+    }
+
+    public static void SaveProject(Project project, string path)
+    {
+        if (!path.EndsWith(".forge", StringComparison.OrdinalIgnoreCase))
+            path += ".forge";
+        SaveToPath(project, path);
+        SetCurrent(project, path);
     }
 }
 

--- a/WordForge/PropertiesWindow.xaml
+++ b/WordForge/PropertiesWindow.xaml
@@ -23,12 +23,37 @@
                 </Setter.Value>
             </Setter>
         </Style>
+        <DropShadowEffect x:Key="Shadow" Color="Black" Opacity="0.5" BlurRadius="10" ShadowDepth="0"/>
     </Window.Resources>
-    <StackPanel Margin="20">
-        <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-            <TextBlock Text="Transitions:" Foreground="#FFE5E7EB" VerticalAlignment="Center" Margin="0,0,8,0"/>
-            <ToggleButton x:Name="TransitionsToggle" Style="{StaticResource ToggleSwitchStyle}" Width="50" Height="24"/>
-            <TextBlock x:Name="ToggleStateText" Foreground="#FFE5E7EB" VerticalAlignment="Center" Margin="8,0,0,0"/>
-        </StackPanel>
-    </StackPanel>
+    <Grid>
+        <Border Margin="20" Background="#FF232529" BorderBrush="#FF3B3F45" BorderThickness="1" CornerRadius="4" Padding="10" Effect="{StaticResource Shadow}">
+            <StackPanel>
+                <StackPanel Orientation="Horizontal" Margin="0,0,0,10">
+                    <TextBlock Text="Title:" Width="60" Foreground="#FFE5E7EB" VerticalAlignment="Center"/>
+                    <TextBox x:Name="TitleBox" Width="220"/>
+                </StackPanel>
+                <StackPanel Orientation="Horizontal" Margin="0,0,0,10">
+                    <TextBlock Text="Author:" Width="60" Foreground="#FFE5E7EB" VerticalAlignment="Center"/>
+                    <TextBox x:Name="AuthorBox" Width="220"/>
+                </StackPanel>
+                <StackPanel Orientation="Horizontal" Margin="0,0,0,10">
+                    <TextBlock Text="Genre:" Width="60" Foreground="#FFE5E7EB" VerticalAlignment="Center"/>
+                    <ComboBox x:Name="GenreBox" Width="220"/>
+                </StackPanel>
+                <StackPanel Orientation="Horizontal" Margin="0,0,0,10">
+                    <TextBlock Text="Save to:" Width="60" Foreground="#FFE5E7EB" VerticalAlignment="Center"/>
+                    <TextBox x:Name="LocationBox" Width="140" IsReadOnly="True"/>
+                    <Button Content="Choose Folder..." Width="100" Margin="4,0,0,0" Click="ChooseFolder_Click"/>
+                </StackPanel>
+                <StackPanel Orientation="Horizontal" VerticalAlignment="Center" Margin="0,0,0,10">
+                    <TextBlock Text="Transitions:" Foreground="#FFE5E7EB" VerticalAlignment="Center" Margin="0,0,8,0"/>
+                    <ToggleButton x:Name="TransitionsToggle" Style="{StaticResource ToggleSwitchStyle}" Width="50" Height="24"/>
+                    <TextBlock x:Name="ToggleStateText" Foreground="#FFE5E7EB" VerticalAlignment="Center" Margin="8,0,0,0"/>
+                </StackPanel>
+                <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
+                    <Button Width="100" Content="Save Changes" Click="Save_Click"/>
+                </StackPanel>
+            </StackPanel>
+        </Border>
+    </Grid>
 </Window>

--- a/WordForge/PropertiesWindow.xaml.cs
+++ b/WordForge/PropertiesWindow.xaml.cs
@@ -1,4 +1,7 @@
+using System;
+using System.IO;
 using System.Windows;
+using WinForms = System.Windows.Forms;
 
 namespace WordForge;
 
@@ -7,6 +10,18 @@ public partial class PropertiesWindow : Window
     public PropertiesWindow()
     {
         InitializeComponent();
+        GenreBox.ItemsSource = new[] { "Fantasy", "Sci-Fi", "Mystery", "Romance", "Other" };
+
+        var project = ProjectService.CurrentProject;
+        TitleBox.Text = project.Title;
+        AuthorBox.Text = project.Author;
+        GenreBox.SelectedItem = project.Genre;
+
+        var location = ProjectService.CurrentPath != null
+            ? Path.GetDirectoryName(ProjectService.CurrentPath)
+            : Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
+        LocationBox.Text = location;
+
         TransitionsToggle.IsChecked = TransitionService.TransitionsEnabled;
         ToggleStateText.Text = TransitionService.TransitionsEnabled ? "On" : "Off";
         TransitionsToggle.Checked += ToggleChanged;
@@ -18,5 +33,31 @@ public partial class PropertiesWindow : Window
         bool enabled = TransitionsToggle.IsChecked == true;
         TransitionService.TransitionsEnabled = enabled;
         ToggleStateText.Text = enabled ? "On" : "Off";
+    }
+
+    private void Save_Click(object sender, RoutedEventArgs e)
+    {
+        var project = ProjectService.CurrentProject;
+        project.Title = TitleBox.Text.Trim();
+        project.Author = AuthorBox.Text.Trim();
+        project.Genre = GenreBox.SelectedItem?.ToString() ?? "";
+
+        var directory = string.IsNullOrWhiteSpace(LocationBox.Text)
+            ? Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments)
+            : LocationBox.Text;
+        Directory.CreateDirectory(directory);
+        var fileName = ProjectService.SanitizeFileName(project.Title) + ".forge";
+        var path = Path.Combine(directory, fileName);
+        ProjectService.SaveProject(project, path);
+        DialogResult = true;
+    }
+
+    private void ChooseFolder_Click(object sender, RoutedEventArgs e)
+    {
+        using var dialog = new WinForms.FolderBrowserDialog { SelectedPath = LocationBox.Text };
+        if (dialog.ShowDialog() == WinForms.DialogResult.OK)
+        {
+            LocationBox.Text = dialog.SelectedPath;
+        }
     }
 }

--- a/WordForge/WordForge.csproj
+++ b/WordForge/WordForge.csproj
@@ -6,6 +6,8 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UseWPF>true</UseWPF>
+    <UseWindowsForms>true</UseWindowsForms>
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
   </PropertyGroup>
 
   <ItemGroup>
@@ -25,6 +27,11 @@
 
   <ItemGroup>
     <Resource Include="resources\images\hamburger.png" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Remove="System.Windows.Forms" />
+    <Using Remove="System.Drawing" />
   </ItemGroup>
 
 </Project>

--- a/WordForge/menus/FileMenu.xaml
+++ b/WordForge/menus/FileMenu.xaml
@@ -5,6 +5,7 @@
         <StackPanel>
             <Button Content="New" Margin="0,0,0,4" Background="#FFE5E7EB" BorderBrush="#FF9CA3AF" Foreground="#FF111111" Click="New_Click" />
             <Button Content="Save" Margin="0,0,0,4" Background="#FFE5E7EB" BorderBrush="#FF9CA3AF" Foreground="#FF111111" Click="Save_Click" />
+            <Button Content="Save As" Margin="0,0,0,4" Background="#FFE5E7EB" BorderBrush="#FF9CA3AF" Foreground="#FF111111" Click="SaveAs_Click" />
             <Button Content="Load" Margin="0,0,0,4" Background="#FFE5E7EB" BorderBrush="#FF9CA3AF" Foreground="#FF111111" Click="Load_Click" />
             <Button Content="Properties" Margin="0,0,0,4" Background="#FFE5E7EB" BorderBrush="#FF9CA3AF" Foreground="#FF111111" Click="Properties_Click"/>
             <Button Content="Print" Margin="0,0,0,4" Background="#FFE5E7EB" BorderBrush="#FF9CA3AF" Foreground="#FF111111" />

--- a/WordForge/menus/FileMenu.xaml.cs
+++ b/WordForge/menus/FileMenu.xaml.cs
@@ -22,13 +22,18 @@ public partial class FileMenu : UserControl
                 Author = window.ProjectAuthor,
                 Genre = window.ProjectGenre
             };
-            ProjectService.CreateNew(project);
+            ProjectService.CreateNew(project, window.ProjectLocation);
         }
     }
 
     private void Save_Click(object sender, RoutedEventArgs e)
     {
         ProjectService.Save();
+    }
+
+    private void SaveAs_Click(object sender, RoutedEventArgs e)
+    {
+        ProjectService.SaveAs();
     }
 
     private void Load_Click(object sender, RoutedEventArgs e)


### PR DESCRIPTION
## Summary
- let users pick a save location in New Project and Properties windows
- add Save As option and location-aware saves in the file menu
- wire up Save Changes to persist metadata and refresh the current project

## Testing
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_68a52dd4bf64833080d02fa9780a7aaf