### PR TITLE
feat: wire center panes to left-rail views

### DIFF
--- a/WordForge/MainWindow.xaml
+++ b/WordForge/MainWindow.xaml
@@ -38,28 +38,7 @@
 
             <!-- Center editor surface -->
             <Grid x:Name="CenterHost" Grid.Column="1" Background="#FF1A1B1E" Margin="12,0,12,0" ClipToBounds="True">
-                <Grid.RowDefinitions>
-                    <RowDefinition Height="28"/>
-                    <!-- Section title -->
-                    <RowDefinition Height="*"/>
-                    <!-- Editor -->
-                    <RowDefinition Height="26"/>
-                    <!-- word/char bar -->
-                </Grid.RowDefinitions>
-
-                <TextBlock Grid.Row="0" Text="INPUT VIEW" Foreground="#FFE5E7EB" FontWeight="Bold" Margin="8,0,0,0" />
-
-                <Border Grid.Row="1" Background="#FF26282C" BorderBrush="#FF3B3F45" BorderThickness="1" CornerRadius="4">
-                    <TextBox AcceptsReturn="True" AcceptsTab="True" TextWrapping="Wrap"
-                             Background="#FF26282C" Foreground="#FFE5E7EB" BorderThickness="0"
-                             VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Auto"
-                             FontSize="14" Padding="10"/>
-                </Border>
-
-                <DockPanel Grid.Row="2" LastChildFill="True" Background="#FF1A1B1E" Margin="2,4,2,0">
-                    <TextBlock DockPanel.Dock="Left" Text="Words: 0" Foreground="#FFC9CDD3" Margin="6,0"/>
-                    <TextBlock DockPanel.Dock="Right" Text="Characters: 0" Foreground="#FFC9CDD3" Margin="6,0"/>
-                </DockPanel>
+                <ContentControl x:Name="CenterContent"/>
             </Grid>
 
             <!-- Right pane (~25%) -->

--- a/WordForge/MainWindow.xaml.cs
+++ b/WordForge/MainWindow.xaml.cs
@@ -9,6 +9,7 @@ using System.Windows.Media.Imaging;
 using System.Windows.Navigation;
 using System.Windows.Shapes;
 using WordForge.Menus.TopMenu;
+using WordForge.Views;
 
 namespace WordForge
 {
@@ -19,6 +20,7 @@ namespace WordForge
     {
         public Grid TopMenuHostElement => TopMenuHost;
         public Grid CenterHostElement => CenterHost;
+        public ContentControl CenterContentElement => CenterContent;
         public Border RightPaneHostElement => RightPaneHost;
 
         public MainWindow()
@@ -27,6 +29,7 @@ namespace WordForge
             RightPaneService.Host = RightPaneContent;
             RightPaneService.Container = RightPaneHost;
             TopMenuContent.Content = new TranscriptMenu();
+            CenterContentElement.Content = new TranscriptView();
             RightPaneService.Show(RightPaneKind.Timeline);
         }
     }

--- a/WordForge/menus/LeftMenu.xaml.cs
+++ b/WordForge/menus/LeftMenu.xaml.cs
@@ -1,6 +1,7 @@
 using System.Windows;
 using System.Windows.Controls;
 using WordForge.Menus.TopMenu;
+using WordForge.Views;
 using WordForge;
 
 namespace WordForge.Menus;
@@ -21,37 +22,49 @@ public partial class LeftMenu : UserControl
 
     private void TranscriptButton_Click(object sender, RoutedEventArgs e)
     {
-        ((MainWindow)Application.Current.MainWindow).TopMenuContent.Content = new TranscriptMenu();
+        var main = (MainWindow)Application.Current.MainWindow;
+        main.TopMenuContent.Content = new TranscriptMenu();
+        main.CenterContentElement.Content = new TranscriptView();
         AnimateMenus();
     }
 
     private void TimelineButton_Click(object sender, RoutedEventArgs e)
     {
-        ((MainWindow)Application.Current.MainWindow).TopMenuContent.Content = new TimelineMenu();
+        var main = (MainWindow)Application.Current.MainWindow;
+        main.TopMenuContent.Content = new TimelineMenu();
+        main.CenterContentElement.Content = new TimelineView();
         AnimateMenus();
     }
 
     private void OutlineButton_Click(object sender, RoutedEventArgs e)
     {
-        ((MainWindow)Application.Current.MainWindow).TopMenuContent.Content = new OutlineMenu();
+        var main = (MainWindow)Application.Current.MainWindow;
+        main.TopMenuContent.Content = new OutlineMenu();
+        main.CenterContentElement.Content = new OutlineView();
         AnimateMenus();
     }
 
     private void CharacterBibleButton_Click(object sender, RoutedEventArgs e)
     {
-        ((MainWindow)Application.Current.MainWindow).TopMenuContent.Content = new CharacterBibleMenu();
+        var main = (MainWindow)Application.Current.MainWindow;
+        main.TopMenuContent.Content = new CharacterBibleMenu();
+        main.CenterContentElement.Content = new CharacterBibleView();
         AnimateMenus();
     }
 
     private void LocationBibleButton_Click(object sender, RoutedEventArgs e)
     {
-        ((MainWindow)Application.Current.MainWindow).TopMenuContent.Content = new LocationBibleMenu();
+        var main = (MainWindow)Application.Current.MainWindow;
+        main.TopMenuContent.Content = new LocationBibleMenu();
+        main.CenterContentElement.Content = new LocationBibleView();
         AnimateMenus();
     }
 
     private void ItemBibleButton_Click(object sender, RoutedEventArgs e)
     {
-        ((MainWindow)Application.Current.MainWindow).TopMenuContent.Content = new ItemBibleMenu();
+        var main = (MainWindow)Application.Current.MainWindow;
+        main.TopMenuContent.Content = new ItemBibleMenu();
+        main.CenterContentElement.Content = new ItemBibleView();
         AnimateMenus();
     }
 }

--- a/WordForge/views/CharacterBibleView.xaml
+++ b/WordForge/views/CharacterBibleView.xaml
@@ -1,0 +1,14 @@
+<UserControl x:Class="WordForge.Views.CharacterBibleView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="28"/>
+            <RowDefinition Height="*"/>
+        </Grid.RowDefinitions>
+
+        <TextBlock Grid.Row="0" Text="CHARACTER BIBLE" Foreground="#FFE5E7EB" FontWeight="Bold" Margin="8,0,0,0"/>
+
+        <Border Grid.Row="1" Background="#FF26282C" BorderBrush="#FF3B3F45" BorderThickness="1" CornerRadius="4"/>
+    </Grid>
+</UserControl>

--- a/WordForge/views/CharacterBibleView.xaml.cs
+++ b/WordForge/views/CharacterBibleView.xaml.cs
@@ -1,0 +1,11 @@
+using System.Windows.Controls;
+
+namespace WordForge.Views;
+
+public partial class CharacterBibleView : UserControl
+{
+    public CharacterBibleView()
+    {
+        InitializeComponent();
+    }
+}

--- a/WordForge/views/ItemBibleView.xaml
+++ b/WordForge/views/ItemBibleView.xaml
@@ -1,0 +1,14 @@
+<UserControl x:Class="WordForge.Views.ItemBibleView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="28"/>
+            <RowDefinition Height="*"/>
+        </Grid.RowDefinitions>
+
+        <TextBlock Grid.Row="0" Text="ITEM BIBLE" Foreground="#FFE5E7EB" FontWeight="Bold" Margin="8,0,0,0"/>
+
+        <Border Grid.Row="1" Background="#FF26282C" BorderBrush="#FF3B3F45" BorderThickness="1" CornerRadius="4"/>
+    </Grid>
+</UserControl>

--- a/WordForge/views/ItemBibleView.xaml.cs
+++ b/WordForge/views/ItemBibleView.xaml.cs
@@ -1,0 +1,11 @@
+using System.Windows.Controls;
+
+namespace WordForge.Views;
+
+public partial class ItemBibleView : UserControl
+{
+    public ItemBibleView()
+    {
+        InitializeComponent();
+    }
+}

--- a/WordForge/views/LocationBibleView.xaml
+++ b/WordForge/views/LocationBibleView.xaml
@@ -1,0 +1,14 @@
+<UserControl x:Class="WordForge.Views.LocationBibleView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="28"/>
+            <RowDefinition Height="*"/>
+        </Grid.RowDefinitions>
+
+        <TextBlock Grid.Row="0" Text="LOCATION BIBLE" Foreground="#FFE5E7EB" FontWeight="Bold" Margin="8,0,0,0"/>
+
+        <Border Grid.Row="1" Background="#FF26282C" BorderBrush="#FF3B3F45" BorderThickness="1" CornerRadius="4"/>
+    </Grid>
+</UserControl>

--- a/WordForge/views/LocationBibleView.xaml.cs
+++ b/WordForge/views/LocationBibleView.xaml.cs
@@ -1,0 +1,11 @@
+using System.Windows.Controls;
+
+namespace WordForge.Views;
+
+public partial class LocationBibleView : UserControl
+{
+    public LocationBibleView()
+    {
+        InitializeComponent();
+    }
+}

--- a/WordForge/views/OutlineView.xaml
+++ b/WordForge/views/OutlineView.xaml
@@ -1,0 +1,14 @@
+<UserControl x:Class="WordForge.Views.OutlineView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="28"/>
+            <RowDefinition Height="*"/>
+        </Grid.RowDefinitions>
+
+        <TextBlock Grid.Row="0" Text="OUTLINE" Foreground="#FFE5E7EB" FontWeight="Bold" Margin="8,0,0,0"/>
+
+        <Border Grid.Row="1" Background="#FF26282C" BorderBrush="#FF3B3F45" BorderThickness="1" CornerRadius="4"/>
+    </Grid>
+</UserControl>

--- a/WordForge/views/OutlineView.xaml.cs
+++ b/WordForge/views/OutlineView.xaml.cs
@@ -1,0 +1,11 @@
+using System.Windows.Controls;
+
+namespace WordForge.Views;
+
+public partial class OutlineView : UserControl
+{
+    public OutlineView()
+    {
+        InitializeComponent();
+    }
+}

--- a/WordForge/views/TimelineView.xaml
+++ b/WordForge/views/TimelineView.xaml
@@ -1,0 +1,14 @@
+<UserControl x:Class="WordForge.Views.TimelineView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="28"/>
+            <RowDefinition Height="*"/>
+        </Grid.RowDefinitions>
+
+        <TextBlock Grid.Row="0" Text="TIMELINE" Foreground="#FFE5E7EB" FontWeight="Bold" Margin="8,0,0,0"/>
+
+        <Border Grid.Row="1" Background="#FF26282C" BorderBrush="#FF3B3F45" BorderThickness="1" CornerRadius="4"/>
+    </Grid>
+</UserControl>

--- a/WordForge/views/TimelineView.xaml.cs
+++ b/WordForge/views/TimelineView.xaml.cs
@@ -1,0 +1,11 @@
+using System.Windows.Controls;
+
+namespace WordForge.Views;
+
+public partial class TimelineView : UserControl
+{
+    public TimelineView()
+    {
+        InitializeComponent();
+    }
+}

--- a/WordForge/views/TranscriptView.xaml
+++ b/WordForge/views/TranscriptView.xaml
@@ -1,0 +1,25 @@
+<UserControl x:Class="WordForge.Views.TranscriptView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="28"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="26"/>
+        </Grid.RowDefinitions>
+
+        <TextBlock Grid.Row="0" Text="TRANSCRIPT" Foreground="#FFE5E7EB" FontWeight="Bold" Margin="8,0,0,0"/>
+
+        <Border Grid.Row="1" Background="#FF26282C" BorderBrush="#FF3B3F45" BorderThickness="1" CornerRadius="4">
+            <TextBox AcceptsReturn="True" AcceptsTab="True" TextWrapping="Wrap"
+                     Background="#FF26282C" Foreground="#FFE5E7EB" BorderThickness="0"
+                     VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Auto"
+                     FontSize="14" Padding="10"/>
+        </Border>
+
+        <DockPanel Grid.Row="2" LastChildFill="True" Background="#FF1A1B1E" Margin="2,4,2,0">
+            <TextBlock DockPanel.Dock="Left" Text="Words: 0" Foreground="#FFC9CDD3" Margin="6,0"/>
+            <TextBlock DockPanel.Dock="Right" Text="Characters: 0" Foreground="#FFC9CDD3" Margin="6,0"/>
+        </DockPanel>
+    </Grid>
+</UserControl>

--- a/WordForge/views/TranscriptView.xaml.cs
+++ b/WordForge/views/TranscriptView.xaml.cs
@@ -1,0 +1,11 @@
+using System.Windows.Controls;
+
+namespace WordForge.Views;
+
+public partial class TranscriptView : UserControl
+{
+    public TranscriptView()
+    {
+        InitializeComponent();
+    }
+}


### PR DESCRIPTION
## Summary
- add dedicated center views for Transcript, Timeline, Outline, Character Bible, Location Bible, and Item Bible
- load corresponding center view when left-rail buttons are clicked
- display word and character counts only in Transcript center view

## Testing
- `/root/.dotnet/dotnet build`
- `/root/.dotnet/dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68a531bbd2bc83309bd823fce703508e