### PR TITLE
0.1.0 - Transcript pane wired

### DIFF
--- a/WordForge/ProjectService.cs
+++ b/WordForge/ProjectService.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Text.Json;
 using System.Windows;
 using Microsoft.Win32;
+using System.Collections.ObjectModel;
 
 namespace WordForge;
 
@@ -15,6 +16,8 @@ public record Project
         = DateTime.Now;
     public DateTime Saved { get; set; }
         = DateTime.Now;
+    public ObservableCollection<Chapter> Chapters { get; set; } = new();
+    public bool IsDirty { get; set; } = false;
 }
 
 public static class ProjectService
@@ -112,12 +115,14 @@ public static class ProjectService
         project.Saved = DateTime.Now;
         var json = JsonSerializer.Serialize(project, new JsonSerializerOptions { WriteIndented = true });
         File.WriteAllText(path, json);
+        project.IsDirty = false;
     }
 
     private static void SetCurrent(Project project, string path)
     {
         CurrentProject = project;
         CurrentPath = path;
+        CurrentProject.IsDirty = false;
         UpdateWindowTitle();
     }
 

--- a/WordForge/TranscriptModels.cs
+++ b/WordForge/TranscriptModels.cs
@@ -1,0 +1,15 @@
+using System.Collections.ObjectModel;
+
+namespace WordForge;
+
+public class Scene
+{
+    public string Title { get; set; } = "Scene";
+    public string Text { get; set; } = string.Empty;
+}
+
+public class Chapter
+{
+    public string Title { get; set; } = "Chapter";
+    public ObservableCollection<Scene> Scenes { get; set; } = new();
+}

--- a/WordForge/views/TranscriptView.xaml
+++ b/WordForge/views/TranscriptView.xaml
@@ -1,25 +1,66 @@
 <UserControl x:Class="WordForge.Views.TranscriptView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:local="clr-namespace:WordForge">
     <Grid>
-        <Grid.RowDefinitions>
-            <RowDefinition Height="28"/>
-            <RowDefinition Height="*"/>
-            <RowDefinition Height="26"/>
-        </Grid.RowDefinitions>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition x:Name="SidebarColumn" Width="220"/>
+            <ColumnDefinition Width="*"/>
+        </Grid.ColumnDefinitions>
 
-        <TextBlock Grid.Row="0" Text="TRANSCRIPT" Foreground="#FFE5E7EB" FontWeight="Bold" Margin="8,0,0,0"/>
-
-        <Border Grid.Row="1" Background="#FF26282C" BorderBrush="#FF3B3F45" BorderThickness="1" CornerRadius="4">
-            <TextBox AcceptsReturn="True" AcceptsTab="True" TextWrapping="Wrap"
-                     Background="#FF26282C" Foreground="#FFE5E7EB" BorderThickness="0"
-                     VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Auto"
-                     FontSize="14" Padding="10"/>
+        <!-- Sidebar for chapters/scenes -->
+        <Border Grid.Column="0" Background="#FF1A1B1E" BorderBrush="#FF3B3F45" BorderThickness="0,0,1,0">
+            <Grid>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="28"/>
+                    <RowDefinition Height="*"/>
+                    <RowDefinition Height="30"/>
+                </Grid.RowDefinitions>
+                <DockPanel Grid.Row="0" LastChildFill="True">
+                    <TextBlock Text="CHAPTERS" Foreground="#FFE5E7EB" FontWeight="Bold" Margin="8,0,0,0"/>
+                    <Button x:Name="CollapseButton" Content="<" Width="20" Height="20" Margin="2" HorizontalAlignment="Right" Click="CollapseButton_Click"/>
+                </DockPanel>
+                <TreeView Grid.Row="1" x:Name="ChapterTree" ItemsSource="{Binding Chapters}" SelectedItemChanged="ChapterTree_SelectedItemChanged" AllowDrop="True" PreviewMouseMove="ChapterTree_PreviewMouseMove" DragOver="ChapterTree_DragOver" Drop="ChapterTree_Drop">
+                    <TreeView.Resources>
+                        <HierarchicalDataTemplate DataType="{x:Type local:Chapter}" ItemsSource="{Binding Scenes}">
+                            <StackPanel Orientation="Horizontal">
+                                <TextBlock Text="{Binding Title}" Width="120"/>
+                                <Button Content="+" Width="20" Height="20" Margin="2" Tag="{Binding}" Click="AddScene_Click" ToolTip="Add Scene"/>
+                                <Button Content="e" Width="20" Height="20" Margin="2" Tag="{Binding}" Click="RenameChapter_Click" ToolTip="Rename Chapter"/>
+                                <Button Content="x" Width="20" Height="20" Margin="2" Tag="{Binding}" Click="DeleteChapter_Click" ToolTip="Delete Chapter"/>
+                            </StackPanel>
+                        </HierarchicalDataTemplate>
+                        <DataTemplate DataType="{x:Type local:Scene}">
+                            <StackPanel Orientation="Horizontal">
+                                <TextBlock Text="{Binding Title}" Width="140"/>
+                                <Button Content="e" Width="20" Height="20" Margin="2" Tag="{Binding}" Click="RenameScene_Click" ToolTip="Rename Scene"/>
+                                <Button Content="x" Width="20" Height="20" Margin="2" Tag="{Binding}" Click="DeleteScene_Click" ToolTip="Delete Scene"/>
+                            </StackPanel>
+                        </DataTemplate>
+                    </TreeView.Resources>
+                </TreeView>
+                <Button Grid.Row="2" Content="Add Chapter" Margin="4" Click="AddChapter_Click"/>
+            </Grid>
         </Border>
 
-        <DockPanel Grid.Row="2" LastChildFill="True" Background="#FF1A1B1E" Margin="2,4,2,0">
-            <TextBlock DockPanel.Dock="Left" Text="Words: 0" Foreground="#FFC9CDD3" Margin="6,0"/>
-            <TextBlock DockPanel.Dock="Right" Text="Characters: 0" Foreground="#FFC9CDD3" Margin="6,0"/>
-        </DockPanel>
+        <!-- Main editor area -->
+        <Grid Grid.Column="1">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="28"/>
+                <RowDefinition Height="*"/>
+                <RowDefinition Height="26"/>
+            </Grid.RowDefinitions>
+            <TextBlock Grid.Row="0" Text="TRANSCRIPT" Foreground="#FFE5E7EB" FontWeight="Bold" Margin="8,0,0,0"/>
+            <Border Grid.Row="1" Background="#FF26282C" BorderBrush="#FF3B3F45" BorderThickness="1" CornerRadius="4">
+                <TextBox x:Name="Editor" AcceptsReturn="True" AcceptsTab="True" TextWrapping="Wrap"
+                         Background="#FF26282C" Foreground="#FFE5E7EB" BorderThickness="0"
+                         VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Auto"
+                         FontSize="14" Padding="10" TextChanged="Editor_TextChanged"/>
+            </Border>
+            <DockPanel Grid.Row="2" LastChildFill="True" Background="#FF1A1B1E" Margin="2,4,2,0">
+                <TextBlock x:Name="WordCountText" DockPanel.Dock="Left" Text="Words: 0" Foreground="#FFC9CDD3" Margin="6,0"/>
+                <TextBlock x:Name="CharCountText" DockPanel.Dock="Right" Text="Characters: 0" Foreground="#FFC9CDD3" Margin="6,0"/>
+            </DockPanel>
+        </Grid>
     </Grid>
 </UserControl>

--- a/WordForge/views/TranscriptView.xaml.cs
+++ b/WordForge/views/TranscriptView.xaml.cs
@@ -1,11 +1,237 @@
+using System;
+using System.Linq;
+using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Input;
+using WordForge;
 
 namespace WordForge.Views;
 
 public partial class TranscriptView : UserControl
 {
+    private Chapter? _selectedChapter;
+    private Scene? _selectedScene;
+    private static bool _sidebarCollapsed = false;
+    private Point _dragStart;
+
     public TranscriptView()
     {
         InitializeComponent();
+        DataContext = ProjectService.CurrentProject;
+        if (_sidebarCollapsed)
+            SidebarColumn.Width = new GridLength(0);
+    }
+
+    private void CollapseButton_Click(object sender, RoutedEventArgs e)
+    {
+        _sidebarCollapsed = !_sidebarCollapsed;
+        SidebarColumn.Width = _sidebarCollapsed ? new GridLength(0) : new GridLength(220);
+    }
+
+    private void AddChapter_Click(object sender, RoutedEventArgs e)
+    {
+        var chapter = new Chapter { Title = $"Chapter {ProjectService.CurrentProject.Chapters.Count + 1}" };
+        chapter.Scenes.Add(new Scene { Title = "Scene 1" });
+        ProjectService.CurrentProject.Chapters.Add(chapter);
+        ProjectService.CurrentProject.IsDirty = true;
+    }
+
+    private void AddScene_Click(object sender, RoutedEventArgs e)
+    {
+        if ((sender as Button)?.Tag is Chapter chapter)
+        {
+            chapter.Scenes.Add(new Scene { Title = $"Scene {chapter.Scenes.Count + 1}" });
+            ProjectService.CurrentProject.IsDirty = true;
+        }
+    }
+
+    private void RenameChapter_Click(object sender, RoutedEventArgs e)
+    {
+        if ((sender as Button)?.Tag is Chapter chapter)
+        {
+            var input = Microsoft.VisualBasic.Interaction.InputBox("Rename chapter", "Rename", chapter.Title);
+            if (!string.IsNullOrWhiteSpace(input))
+            {
+                chapter.Title = input;
+                ProjectService.CurrentProject.IsDirty = true;
+            }
+        }
+    }
+
+    private void RenameScene_Click(object sender, RoutedEventArgs e)
+    {
+        if ((sender as Button)?.Tag is Scene scene)
+        {
+            var input = Microsoft.VisualBasic.Interaction.InputBox("Rename scene", "Rename", scene.Title);
+            if (!string.IsNullOrWhiteSpace(input))
+            {
+                scene.Title = input;
+                ProjectService.CurrentProject.IsDirty = true;
+            }
+        }
+    }
+
+    private void DeleteChapter_Click(object sender, RoutedEventArgs e)
+    {
+        if ((sender as Button)?.Tag is Chapter chapter)
+        {
+            if (MessageBox.Show("Delete chapter and all scenes?", "Confirm", MessageBoxButton.YesNo) == MessageBoxResult.Yes)
+            {
+                ProjectService.CurrentProject.Chapters.Remove(chapter);
+                ProjectService.CurrentProject.IsDirty = true;
+            }
+        }
+    }
+
+    private void DeleteScene_Click(object sender, RoutedEventArgs e)
+    {
+        if ((sender as Button)?.Tag is Scene scene)
+        {
+            foreach (var chapter in ProjectService.CurrentProject.Chapters)
+            {
+                if (chapter.Scenes.Contains(scene))
+                {
+                    if (MessageBox.Show("Delete scene?", "Confirm", MessageBoxButton.YesNo) == MessageBoxResult.Yes)
+                    {
+                        chapter.Scenes.Remove(scene);
+                        ProjectService.CurrentProject.IsDirty = true;
+                    }
+                    break;
+                }
+            }
+        }
+    }
+
+    private void ChapterTree_SelectedItemChanged(object sender, RoutedPropertyChangedEventArgs<object> e)
+    {
+        _selectedScene = e.NewValue as Scene;
+        _selectedChapter = e.NewValue as Chapter;
+        if (_selectedScene != null)
+        {
+            Editor.Text = _selectedScene.Text;
+        }
+        else if (_selectedChapter != null)
+        {
+            Editor.Text = string.Join("\n***\n", _selectedChapter.Scenes.Select(s => s.Text));
+        }
+        UpdateCounts();
+    }
+
+    private void Editor_TextChanged(object sender, TextChangedEventArgs e)
+    {
+        if (_selectedScene != null)
+        {
+            _selectedScene.Text = Editor.Text;
+        }
+        else if (_selectedChapter != null)
+        {
+            var parts = Editor.Text.Split("\n***\n", StringSplitOptions.None);
+            for (int i = 0; i < _selectedChapter.Scenes.Count; i++)
+            {
+                _selectedChapter.Scenes[i].Text = i < parts.Length ? parts[i] : string.Empty;
+            }
+        }
+        ProjectService.CurrentProject.IsDirty = true;
+        UpdateCounts();
+    }
+
+    private void UpdateCounts()
+    {
+        var text = Editor.Text;
+        if (_selectedChapter != null)
+        {
+            text = string.Join("\n", text.Split('\n').Where(l => l != "***"));
+        }
+        var words = string.IsNullOrWhiteSpace(text)
+            ? 0
+            : text.Split(new[] { ' ', '\n', '\r', '\t' }, StringSplitOptions.RemoveEmptyEntries).Length;
+        var chars = text.Replace("\r", string.Empty).Replace("\n", string.Empty).Length;
+        WordCountText.Text = $"Words: {words}";
+        CharCountText.Text = $"Characters: {chars}";
+    }
+
+    // Drag and drop handling
+    private void ChapterTree_PreviewMouseMove(object sender, MouseEventArgs e)
+    {
+        if (e.LeftButton == MouseButtonState.Pressed)
+        {
+            if (_dragStart == default)
+                _dragStart = e.GetPosition(null);
+            var diff = e.GetPosition(null) - _dragStart;
+            if (Math.Abs(diff.X) > SystemParameters.MinimumHorizontalDragDistance || Math.Abs(diff.Y) > SystemParameters.MinimumVerticalDragDistance)
+            {
+                if (ChapterTree.SelectedItem != null)
+                {
+                    DragDrop.DoDragDrop(ChapterTree, ChapterTree.SelectedItem, DragDropEffects.Move);
+                }
+            }
+        }
+    }
+
+    private void ChapterTree_DragOver(object sender, DragEventArgs e)
+    {
+        e.Effects = DragDropEffects.None;
+        if (e.Data.GetDataPresent(typeof(Chapter)) || e.Data.GetDataPresent(typeof(Scene)))
+        {
+            e.Effects = DragDropEffects.Move;
+        }
+        e.Handled = true;
+    }
+
+    private void ChapterTree_Drop(object sender, DragEventArgs e)
+    {
+        if (e.Data.GetData(typeof(Chapter)) is Chapter chapter)
+        {
+            if (e.OriginalSource is FrameworkElement fe && fe.DataContext is Chapter targetChapter)
+            {
+                if (chapter != targetChapter)
+                {
+                    var list = ProjectService.CurrentProject.Chapters;
+                    var oldIndex = list.IndexOf(chapter);
+                    var newIndex = list.IndexOf(targetChapter);
+                    if (oldIndex >= 0 && newIndex >= 0)
+                    {
+                        list.Move(oldIndex, newIndex);
+                        ProjectService.CurrentProject.IsDirty = true;
+                    }
+                }
+            }
+        }
+        else if (e.Data.GetData(typeof(Scene)) is Scene scene)
+        {
+            if (e.OriginalSource is FrameworkElement fe)
+            {
+                if (fe.DataContext is Scene targetScene)
+                {
+                    foreach (var ch in ProjectService.CurrentProject.Chapters)
+                    {
+                        if (ch.Scenes.Contains(scene) && ch.Scenes.Contains(targetScene))
+                        {
+                            var oldIndex = ch.Scenes.IndexOf(scene);
+                            var newIndex = ch.Scenes.IndexOf(targetScene);
+                            if (oldIndex >= 0 && newIndex >= 0)
+                            {
+                                ch.Scenes.Move(oldIndex, newIndex);
+                                ProjectService.CurrentProject.IsDirty = true;
+                            }
+                            return;
+                        }
+                    }
+                }
+                else if (fe.DataContext is Chapter targetChapter)
+                {
+                    foreach (var ch in ProjectService.CurrentProject.Chapters)
+                    {
+                        if (ch.Scenes.Contains(scene))
+                        {
+                            ch.Scenes.Remove(scene);
+                            targetChapter.Scenes.Add(scene);
+                            ProjectService.CurrentProject.IsDirty = true;
+                            return;
+                        }
+                    }
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary
- introduce chapter/scene data models with project dirty tracking
- add transcript sidebar with chapter/scene tree and actions
- load selection into editor with live word/character counts and drag-and-drop reordering

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a538e8d788833089feb8597218d6bd