### PR TITLE
Improve transcript sidebar and menus

### DIFF
--- a/WordForge/views/TranscriptView.xaml
+++ b/WordForge/views/TranscriptView.xaml
@@ -4,6 +4,7 @@
              xmlns:local="clr-namespace:WordForge">
     <Grid>
         <Grid.ColumnDefinitions>
+            <!-- Column 0 holds the sidebar and collapse ribbon -->
             <ColumnDefinition x:Name="SidebarColumn" Width="220"/>
             <ColumnDefinition Width="*"/>
         </Grid.ColumnDefinitions>
@@ -16,30 +17,73 @@
                     <RowDefinition Height="*"/>
                     <RowDefinition Height="30"/>
                 </Grid.RowDefinitions>
-                <DockPanel Grid.Row="0" LastChildFill="True">
-                    <TextBlock Text="CHAPTERS" Foreground="#FFE5E7EB" FontWeight="Bold" Margin="8,0,0,0"/>
+                <DockPanel Grid.Row="0" LastChildFill="True" x:Name="SidebarHeader">
+                    <TextBlock x:Name="ChaptersLabel" Text="CHAPTERS" Foreground="#FFE5E7EB" FontWeight="Bold" Margin="8,0,0,0"/>
+                    <!-- Toggle collapse/expand -->
                     <Button x:Name="CollapseButton" Content="&lt;" Width="20" Height="20" Margin="2" HorizontalAlignment="Right" Click="CollapseButton_Click"/>
                 </DockPanel>
                 <TreeView Grid.Row="1" x:Name="ChapterTree" ItemsSource="{Binding Chapters}" SelectedItemChanged="ChapterTree_SelectedItemChanged" AllowDrop="True" PreviewMouseMove="ChapterTree_PreviewMouseMove" DragOver="ChapterTree_DragOver" Drop="ChapterTree_Drop">
                     <TreeView.Resources>
+                        <!-- Chapter template with hover menu button -->
                         <HierarchicalDataTemplate DataType="{x:Type local:Chapter}" ItemsSource="{Binding Scenes}">
-                            <StackPanel Orientation="Horizontal">
+                            <Grid>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="Auto"/>
+                                </Grid.ColumnDefinitions>
                                 <TextBlock Text="{Binding Title}" Width="120"/>
-                                <Button Content="+" Width="20" Height="20" Margin="2" Tag="{Binding}" Click="AddScene_Click" ToolTip="Add Scene"/>
-                                <Button Content="e" Width="20" Height="20" Margin="2" Tag="{Binding}" Click="RenameChapter_Click" ToolTip="Rename Chapter"/>
-                                <Button Content="x" Width="20" Height="20" Margin="2" Tag="{Binding}" Click="DeleteChapter_Click" ToolTip="Delete Chapter"/>
-                            </StackPanel>
+                                <Button x:Name="ChapterMenuButton" Grid.Column="1" Content="⋮" Width="20" Height="20" Margin="2" Tag="{Binding}" Click="OpenChapterMenu" Visibility="Collapsed">
+                                    <Button.ContextMenu>
+                                        <ContextMenu>
+                                            <MenuItem Header="Add Scene" Tag="{Binding}" Click="AddScene_Click"/>
+                                            <MenuItem Header="Rename" Tag="{Binding}" Click="RenameChapter_Click"/>
+                                            <MenuItem Header="Delete" Tag="{Binding}" Click="DeleteChapter_Click"/>
+                                        </ContextMenu>
+                                    </Button.ContextMenu>
+                                    <Button.Style>
+                                        <Style TargetType="Button" BasedOn="{StaticResource {x:Type Button}}">
+                                            <Setter Property="Visibility" Value="Collapsed"/>
+                                            <Style.Triggers>
+                                                <DataTrigger Binding="{Binding IsMouseOver, RelativeSource={RelativeSource AncestorType=TreeViewItem}}" Value="True">
+                                                    <Setter Property="Visibility" Value="Visible"/>
+                                                </DataTrigger>
+                                            </Style.Triggers>
+                                        </Style>
+                                    </Button.Style>
+                                </Button>
+                            </Grid>
                         </HierarchicalDataTemplate>
+                        <!-- Scene template with hover menu button -->
                         <DataTemplate DataType="{x:Type local:Scene}">
-                            <StackPanel Orientation="Horizontal">
+                            <Grid>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="Auto"/>
+                                </Grid.ColumnDefinitions>
                                 <TextBlock Text="{Binding Title}" Width="140"/>
-                                <Button Content="e" Width="20" Height="20" Margin="2" Tag="{Binding}" Click="RenameScene_Click" ToolTip="Rename Scene"/>
-                                <Button Content="x" Width="20" Height="20" Margin="2" Tag="{Binding}" Click="DeleteScene_Click" ToolTip="Delete Scene"/>
-                            </StackPanel>
+                                <Button x:Name="SceneMenuButton" Grid.Column="1" Content="⋮" Width="20" Height="20" Margin="2" Tag="{Binding}" Click="OpenSceneMenu" Visibility="Collapsed">
+                                    <Button.ContextMenu>
+                                        <ContextMenu>
+                                            <MenuItem Header="Rename" Tag="{Binding}" Click="RenameScene_Click"/>
+                                            <MenuItem Header="Delete" Tag="{Binding}" Click="DeleteScene_Click"/>
+                                        </ContextMenu>
+                                    </Button.ContextMenu>
+                                    <Button.Style>
+                                        <Style TargetType="Button" BasedOn="{StaticResource {x:Type Button}}">
+                                            <Setter Property="Visibility" Value="Collapsed"/>
+                                            <Style.Triggers>
+                                                <DataTrigger Binding="{Binding IsMouseOver, RelativeSource={RelativeSource AncestorType=TreeViewItem}}" Value="True">
+                                                    <Setter Property="Visibility" Value="Visible"/>
+                                                </DataTrigger>
+                                            </Style.Triggers>
+                                        </Style>
+                                    </Button.Style>
+                                </Button>
+                            </Grid>
                         </DataTemplate>
                     </TreeView.Resources>
                 </TreeView>
-                <Button Grid.Row="2" Content="Add Chapter" Margin="4" Click="AddChapter_Click"/>
+                <Button x:Name="AddChapterButton" Grid.Row="2" Content="Add Chapter" Margin="4" Click="AddChapter_Click"/>
             </Grid>
         </Border>
 
@@ -54,7 +98,7 @@
             <Border Grid.Row="1" Background="#FF26282C" BorderBrush="#FF3B3F45" BorderThickness="1" CornerRadius="4">
                 <TextBox x:Name="Editor" AcceptsReturn="True" AcceptsTab="True" TextWrapping="Wrap"
                          Background="#FF26282C" Foreground="#FFE5E7EB" BorderThickness="0"
-                         VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Auto"
+                         VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled"
                          FontSize="14" Padding="10" TextChanged="Editor_TextChanged"/>
             </Border>
             <DockPanel Grid.Row="2" LastChildFill="True" Background="#FF1A1B1E" Margin="2,4,2,0">

--- a/WordForge/views/TranscriptView.xaml.cs
+++ b/WordForge/views/TranscriptView.xaml.cs
@@ -19,13 +19,34 @@ public partial class TranscriptView : UserControl
         InitializeComponent();
         DataContext = ProjectService.CurrentProject;
         if (_sidebarCollapsed)
-            SidebarColumn.Width = new GridLength(0);
+        {
+            SidebarColumn.Width = new GridLength(24);
+            ChaptersLabel.Visibility = Visibility.Collapsed;
+            ChapterTree.Visibility = Visibility.Collapsed;
+            AddChapterButton.Visibility = Visibility.Collapsed;
+            CollapseButton.Content = ">";
+        }
     }
 
     private void CollapseButton_Click(object sender, RoutedEventArgs e)
     {
         _sidebarCollapsed = !_sidebarCollapsed;
-        SidebarColumn.Width = _sidebarCollapsed ? new GridLength(0) : new GridLength(220);
+        if (_sidebarCollapsed)
+        {
+            SidebarColumn.Width = new GridLength(24);
+            ChaptersLabel.Visibility = Visibility.Collapsed;
+            ChapterTree.Visibility = Visibility.Collapsed;
+            AddChapterButton.Visibility = Visibility.Collapsed;
+            CollapseButton.Content = ">";
+        }
+        else
+        {
+            SidebarColumn.Width = new GridLength(220);
+            ChaptersLabel.Visibility = Visibility.Visible;
+            ChapterTree.Visibility = Visibility.Visible;
+            AddChapterButton.Visibility = Visibility.Visible;
+            CollapseButton.Content = "<";
+        }
     }
 
     private void AddChapter_Click(object sender, RoutedEventArgs e)
@@ -38,11 +59,27 @@ public partial class TranscriptView : UserControl
 
     private void AddScene_Click(object sender, RoutedEventArgs e)
     {
-        if ((sender as Button)?.Tag is Chapter chapter)
+        var chapter = (sender as FrameworkElement)?.Tag as Chapter;
+        if (chapter == null) return;
+
+        // Ensure unique default name
+        int idx = 1;
+        string name;
+        do
         {
-            chapter.Scenes.Add(new Scene { Title = $"Scene {chapter.Scenes.Count + 1}" });
-            ProjectService.CurrentProject.IsDirty = true;
-        }
+            name = $"Scene {idx++}";
+        } while (chapter.Scenes.Any(s => s.Title == name));
+
+        var scene = new Scene { Title = name };
+        chapter.Scenes.Add(scene);
+        ProjectService.CurrentProject.IsDirty = true;
+
+        // Select the new scene
+        _selectedScene = scene;
+        _selectedChapter = null;
+        ChapterTree.SelectedItem = scene;
+        Editor.Text = scene.Text;
+        UpdateCounts();
     }
 
     private void RenameChapter_Click(object sender, RoutedEventArgs e)
@@ -73,31 +110,69 @@ public partial class TranscriptView : UserControl
 
     private void DeleteChapter_Click(object sender, RoutedEventArgs e)
     {
-        if ((sender as Button)?.Tag is Chapter chapter)
+        var chapter = (sender as FrameworkElement)?.Tag as Chapter;
+        if (chapter == null) return;
+        if (MessageBox.Show("Delete chapter and all scenes?", "Confirm", MessageBoxButton.YesNo) == MessageBoxResult.Yes)
         {
-            if (MessageBox.Show("Delete chapter and all scenes?", "Confirm", MessageBoxButton.YesNo) == MessageBoxResult.Yes)
+            var list = ProjectService.CurrentProject.Chapters;
+            var index = list.IndexOf(chapter);
+            list.Remove(chapter);
+            ProjectService.CurrentProject.IsDirty = true;
+            // Select neighbor
+            if (list.Count > 0)
             {
-                ProjectService.CurrentProject.Chapters.Remove(chapter);
-                ProjectService.CurrentProject.IsDirty = true;
+                var newIndex = Math.Min(index, list.Count - 1);
+                var newChapter = list[newIndex];
+                ChapterTree.SelectedItem = newChapter;
+                _selectedChapter = newChapter;
+                _selectedScene = null;
+                Editor.Text = string.Join("\n***\n", newChapter.Scenes.Select(s => s.Text));
             }
+            else
+            {
+                ChapterTree.SelectedItem = null;
+                _selectedChapter = null;
+                _selectedScene = null;
+                Editor.Text = string.Empty;
+            }
+            UpdateCounts();
         }
     }
 
     private void DeleteScene_Click(object sender, RoutedEventArgs e)
     {
-        if ((sender as Button)?.Tag is Scene scene)
+        var scene = (sender as FrameworkElement)?.Tag as Scene;
+        if (scene == null) return;
+        foreach (var chapter in ProjectService.CurrentProject.Chapters)
         {
-            foreach (var chapter in ProjectService.CurrentProject.Chapters)
+            if (chapter.Scenes.Contains(scene))
             {
-                if (chapter.Scenes.Contains(scene))
+                if (MessageBox.Show("Delete scene?", "Confirm", MessageBoxButton.YesNo) == MessageBoxResult.Yes)
                 {
-                    if (MessageBox.Show("Delete scene?", "Confirm", MessageBoxButton.YesNo) == MessageBoxResult.Yes)
+                    var list = chapter.Scenes;
+                    var index = list.IndexOf(scene);
+                    list.Remove(scene);
+                    ProjectService.CurrentProject.IsDirty = true;
+                    // Select neighbor scene or chapter
+                    if (list.Count > 0)
                     {
-                        chapter.Scenes.Remove(scene);
-                        ProjectService.CurrentProject.IsDirty = true;
+                        var newIndex = Math.Min(index, list.Count - 1);
+                        var newScene = list[newIndex];
+                        ChapterTree.SelectedItem = newScene;
+                        _selectedScene = newScene;
+                        _selectedChapter = null;
+                        Editor.Text = newScene.Text;
                     }
-                    break;
+                    else
+                    {
+                        ChapterTree.SelectedItem = chapter;
+                        _selectedScene = null;
+                        _selectedChapter = chapter;
+                        Editor.Text = string.Join("\n***\n", chapter.Scenes.Select(s => s.Text));
+                    }
+                    UpdateCounts();
                 }
+                break;
             }
         }
     }
@@ -115,6 +190,24 @@ public partial class TranscriptView : UserControl
             Editor.Text = string.Join("\n***\n", _selectedChapter.Scenes.Select(s => s.Text));
         }
         UpdateCounts();
+    }
+
+    private void OpenChapterMenu(object sender, RoutedEventArgs e)
+    {
+        if (sender is Button btn && btn.ContextMenu != null)
+        {
+            btn.ContextMenu.PlacementTarget = btn;
+            btn.ContextMenu.IsOpen = true;
+        }
+    }
+
+    private void OpenSceneMenu(object sender, RoutedEventArgs e)
+    {
+        if (sender is Button btn && btn.ContextMenu != null)
+        {
+            btn.ContextMenu.PlacementTarget = btn;
+            btn.ContextMenu.IsOpen = true;
+        }
     }
 
     private void Editor_TextChanged(object sender, TextChangedEventArgs e)


### PR DESCRIPTION
## Summary
- add collapsible sidebar ribbon with persistent state
- replace per-row buttons with contextual three-dot menus
- make scene additions unique and auto-select new scene
- streamline delete operations and neighbor selection
- remove horizontal scrollbar in editor

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a53dbb7218833084746f5ee39f18d2