### PR TITLE
Enhance chapter/scene sidebar and context menus

### DIFF
--- a/WordForge/views/TranscriptView.xaml
+++ b/WordForge/views/TranscriptView.xaml
@@ -22,66 +22,137 @@
                     <!-- Toggle collapse/expand -->
                     <Button x:Name="CollapseButton" Content="&lt;" Width="20" Height="20" Margin="2" HorizontalAlignment="Right" Click="CollapseButton_Click"/>
                 </DockPanel>
-                <TreeView Grid.Row="1" x:Name="ChapterTree" ItemsSource="{Binding Chapters}" SelectedItemChanged="ChapterTree_SelectedItemChanged" AllowDrop="True" PreviewMouseMove="ChapterTree_PreviewMouseMove" DragOver="ChapterTree_DragOver" Drop="ChapterTree_Drop">
+                <TreeView Grid.Row="1" x:Name="ChapterTree" ItemsSource="{Binding Chapters}" SelectedItemChanged="ChapterTree_SelectedItemChanged" AllowDrop="True" PreviewMouseMove="ChapterTree_PreviewMouseMove" DragOver="ChapterTree_DragOver" Drop="ChapterTree_Drop" ScrollViewer.HorizontalScrollBarVisibility="Disabled" PreviewMouseRightButtonDown="ChapterTree_PreviewMouseRightButtonDown">
                     <TreeView.Resources>
-                        <!-- Chapter template with hover menu button -->
-                        <HierarchicalDataTemplate DataType="{x:Type local:Chapter}" ItemsSource="{Binding Scenes}">
-                            <Grid>
-                                <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="*"/>
-                                    <ColumnDefinition Width="Auto"/>
-                                </Grid.ColumnDefinitions>
-                                <TextBlock Text="{Binding Title}" Width="120"/>
-                                <Button x:Name="ChapterMenuButton" Grid.Column="1" Content="⋮" Width="20" Height="20" Margin="2" Tag="{Binding}" Click="OpenChapterMenu" Visibility="Collapsed">
-                                    <Button.ContextMenu>
-                                        <ContextMenu>
-                                            <MenuItem Header="Add Scene" Tag="{Binding}" Click="AddScene_Click"/>
-                                            <MenuItem Header="Rename" Tag="{Binding}" Click="RenameChapter_Click"/>
-                                            <MenuItem Header="Delete" Tag="{Binding}" Click="DeleteChapter_Click"/>
-                                        </ContextMenu>
-                                    </Button.ContextMenu>
-                                    <Button.Style>
-                                        <Style TargetType="Button" BasedOn="{StaticResource {x:Type Button}}">
-                                            <Setter Property="Visibility" Value="Collapsed"/>
-                                            <Style.Triggers>
-                                                <DataTrigger Binding="{Binding IsMouseOver, RelativeSource={RelativeSource AncestorType=TreeViewItem}}" Value="True">
-                                                    <Setter Property="Visibility" Value="Visible"/>
-                                                </DataTrigger>
-                                            </Style.Triggers>
-                                        </Style>
-                                    </Button.Style>
-                                </Button>
-                            </Grid>
+                        <ContextMenu x:Key="ChapterContextMenu" x:Shared="False" Background="#FF26282C" BorderBrush="#FF3B3F45" Foreground="#FFE5E7EB">
+                            <ContextMenu.Resources>
+                                <Style TargetType="MenuItem">
+                                    <Setter Property="Background" Value="#FF26282C"/>
+                                    <Setter Property="Foreground" Value="#FFE5E7EB"/>
+                                    <Setter Property="BorderBrush" Value="#FF3B3F45"/>
+                                    <Setter Property="Padding" Value="6,2"/>
+                                    <Style.Triggers>
+                                        <Trigger Property="IsHighlighted" Value="True">
+                                            <Setter Property="Background" Value="#FF2F3237"/>
+                                        </Trigger>
+                                    </Style.Triggers>
+                                </Style>
+                            </ContextMenu.Resources>
+                            <MenuItem Header="Add Scene" Tag="{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource AncestorType=ContextMenu}}" Click="AddScene_Click"/>
+                            <MenuItem Header="Rename" Tag="{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource AncestorType=ContextMenu}}" Click="RenameChapter_Click"/>
+                            <MenuItem Header="Delete" Tag="{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource AncestorType=ContextMenu}}" Click="DeleteChapter_Click"/>
+                        </ContextMenu>
+                        <ContextMenu x:Key="SceneContextMenu" x:Shared="False" Background="#FF26282C" BorderBrush="#FF3B3F45" Foreground="#FFE5E7EB">
+                            <ContextMenu.Resources>
+                                <Style TargetType="MenuItem">
+                                    <Setter Property="Background" Value="#FF26282C"/>
+                                    <Setter Property="Foreground" Value="#FFE5E7EB"/>
+                                    <Setter Property="BorderBrush" Value="#FF3B3F45"/>
+                                    <Setter Property="Padding" Value="6,2"/>
+                                    <Style.Triggers>
+                                        <Trigger Property="IsHighlighted" Value="True">
+                                            <Setter Property="Background" Value="#FF2F3237"/>
+                                        </Trigger>
+                                    </Style.Triggers>
+                                </Style>
+                            </ContextMenu.Resources>
+                            <MenuItem Header="Rename" Tag="{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource AncestorType=ContextMenu}}" Click="RenameScene_Click"/>
+                            <MenuItem Header="Delete" Tag="{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource AncestorType=ContextMenu}}" Click="DeleteScene_Click"/>
+                        </ContextMenu>
+                        <Style x:Key="ChapterItemStyle" TargetType="TreeViewItem">
+                            <Setter Property="ContextMenu" Value="{StaticResource ChapterContextMenu}"/>
+                            <Setter Property="Padding" Value="0"/>
+                        </Style>
+                        <Style x:Key="SceneItemStyle" TargetType="TreeViewItem">
+                            <Setter Property="ContextMenu" Value="{StaticResource SceneContextMenu}"/>
+                            <Setter Property="Padding" Value="0"/>
+                        </Style>
+                        <!-- Chapter template with overflow button -->
+                        <HierarchicalDataTemplate DataType="{x:Type local:Chapter}" ItemsSource="{Binding Scenes}" ItemContainerStyle="{StaticResource SceneItemStyle}">
+                            <Border x:Name="ChapterBorder" Padding="4,2" BorderThickness="0,0,0,1" BorderBrush="#FF3B3F45">
+                                <Grid>
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="*"/>
+                                        <ColumnDefinition Width="Auto"/>
+                                    </Grid.ColumnDefinitions>
+                                    <TextBlock x:Name="ChapterText" Grid.Column="0" Text="{Binding Title}" Foreground="#FFE5E7EB" TextTrimming="CharacterEllipsis" ToolTip="{Binding Title}" VerticalAlignment="Center"/>
+                                    <TextBox x:Name="ChapterEditBox" Grid.Column="0" Text="{Binding Title, UpdateSourceTrigger=Explicit}" Visibility="Collapsed" Background="#FF26282C" Foreground="#FFE5E7EB" BorderBrush="#FF3B3F45" BorderThickness="1" KeyDown="RenameBox_KeyDown" LostFocus="RenameBox_LostFocus"/>
+                                    <Button x:Name="ChapterMenuButton" Grid.Column="1" Content="⋮" Width="20" Height="20" Margin="0" Click="OpenItemMenu" Visibility="Hidden" Focusable="True">
+                                        <Button.Style>
+                                            <Style TargetType="Button">
+                                                <Setter Property="Visibility" Value="Hidden"/>
+                                                <Style.Triggers>
+                                                    <DataTrigger Binding="{Binding IsMouseOver, RelativeSource={RelativeSource AncestorType=TreeViewItem}}" Value="True">
+                                                        <Setter Property="Visibility" Value="Visible"/>
+                                                    </DataTrigger>
+                                                    <DataTrigger Binding="{Binding IsSelected, RelativeSource={RelativeSource AncestorType=TreeViewItem}}" Value="True">
+                                                        <Setter Property="Visibility" Value="Visible"/>
+                                                    </DataTrigger>
+                                                </Style.Triggers>
+                                            </Style>
+                                        </Button.Style>
+                                    </Button>
+                                </Grid>
+                                <Border.Style>
+                                    <Style TargetType="Border">
+                                        <Setter Property="Background" Value="Transparent"/>
+                                        <Style.Triggers>
+                                            <DataTrigger Binding="{Binding IsMouseOver, RelativeSource={RelativeSource AncestorType=TreeViewItem}}" Value="True">
+                                                <Setter Property="Background" Value="#FF2F3237"/>
+                                            </DataTrigger>
+                                            <DataTrigger Binding="{Binding IsSelected, RelativeSource={RelativeSource AncestorType=TreeViewItem}}" Value="True">
+                                                <Setter Property="Background" Value="#FF34363B"/>
+                                            </DataTrigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </Border.Style>
+                            </Border>
                         </HierarchicalDataTemplate>
-                        <!-- Scene template with hover menu button -->
+                        <!-- Scene template with overflow button -->
                         <DataTemplate DataType="{x:Type local:Scene}">
-                            <Grid>
-                                <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="*"/>
-                                    <ColumnDefinition Width="Auto"/>
-                                </Grid.ColumnDefinitions>
-                                <TextBlock Text="{Binding Title}" Width="140"/>
-                                <Button x:Name="SceneMenuButton" Grid.Column="1" Content="⋮" Width="20" Height="20" Margin="2" Tag="{Binding}" Click="OpenSceneMenu" Visibility="Collapsed">
-                                    <Button.ContextMenu>
-                                        <ContextMenu>
-                                            <MenuItem Header="Rename" Tag="{Binding}" Click="RenameScene_Click"/>
-                                            <MenuItem Header="Delete" Tag="{Binding}" Click="DeleteScene_Click"/>
-                                        </ContextMenu>
-                                    </Button.ContextMenu>
-                                    <Button.Style>
-                                        <Style TargetType="Button" BasedOn="{StaticResource {x:Type Button}}">
-                                            <Setter Property="Visibility" Value="Collapsed"/>
-                                            <Style.Triggers>
-                                                <DataTrigger Binding="{Binding IsMouseOver, RelativeSource={RelativeSource AncestorType=TreeViewItem}}" Value="True">
-                                                    <Setter Property="Visibility" Value="Visible"/>
-                                                </DataTrigger>
-                                            </Style.Triggers>
-                                        </Style>
-                                    </Button.Style>
-                                </Button>
-                            </Grid>
+                            <Border x:Name="SceneBorder" Padding="4,2" BorderThickness="0,0,0,1" BorderBrush="#FF3B3F45">
+                                <Grid>
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="*"/>
+                                        <ColumnDefinition Width="Auto"/>
+                                    </Grid.ColumnDefinitions>
+                                    <TextBlock x:Name="SceneText" Grid.Column="0" Text="{Binding Title}" Foreground="#FFE5E7EB" TextTrimming="CharacterEllipsis" ToolTip="{Binding Title}" VerticalAlignment="Center"/>
+                                    <TextBox x:Name="SceneEditBox" Grid.Column="0" Text="{Binding Title, UpdateSourceTrigger=Explicit}" Visibility="Collapsed" Background="#FF26282C" Foreground="#FFE5E7EB" BorderBrush="#FF3B3F45" BorderThickness="1" KeyDown="RenameBox_KeyDown" LostFocus="RenameBox_LostFocus"/>
+                                    <Button x:Name="SceneMenuButton" Grid.Column="1" Content="⋮" Width="20" Height="20" Margin="0" Click="OpenItemMenu" Visibility="Hidden" Focusable="True">
+                                        <Button.Style>
+                                            <Style TargetType="Button">
+                                                <Setter Property="Visibility" Value="Hidden"/>
+                                                <Style.Triggers>
+                                                    <DataTrigger Binding="{Binding IsMouseOver, RelativeSource={RelativeSource AncestorType=TreeViewItem}}" Value="True">
+                                                        <Setter Property="Visibility" Value="Visible"/>
+                                                    </DataTrigger>
+                                                    <DataTrigger Binding="{Binding IsSelected, RelativeSource={RelativeSource AncestorType=TreeViewItem}}" Value="True">
+                                                        <Setter Property="Visibility" Value="Visible"/>
+                                                    </DataTrigger>
+                                                </Style.Triggers>
+                                            </Style>
+                                        </Button.Style>
+                                    </Button>
+                                </Grid>
+                                <Border.Style>
+                                    <Style TargetType="Border">
+                                        <Setter Property="Background" Value="Transparent"/>
+                                        <Style.Triggers>
+                                            <DataTrigger Binding="{Binding IsMouseOver, RelativeSource={RelativeSource AncestorType=TreeViewItem}}" Value="True">
+                                                <Setter Property="Background" Value="#FF2F3237"/>
+                                            </DataTrigger>
+                                            <DataTrigger Binding="{Binding IsSelected, RelativeSource={RelativeSource AncestorType=TreeViewItem}}" Value="True">
+                                                <Setter Property="Background" Value="#FF34363B"/>
+                                            </DataTrigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </Border.Style>
+                            </Border>
                         </DataTemplate>
                     </TreeView.Resources>
+                    <TreeView.ItemContainerStyle>
+                        <StaticResource ResourceKey="ChapterItemStyle"/>
+                    </TreeView.ItemContainerStyle>
                 </TreeView>
                 <Button x:Name="AddChapterButton" Grid.Row="2" Content="Add Chapter" Margin="4" Click="AddChapter_Click"/>
             </Grid>

--- a/WordForge/views/TranscriptView.xaml.cs
+++ b/WordForge/views/TranscriptView.xaml.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
+using System.Windows.Media;
 using WordForge;
 
 namespace WordForge.Views;
@@ -84,26 +85,49 @@ public partial class TranscriptView : UserControl
 
     private void RenameChapter_Click(object sender, RoutedEventArgs e)
     {
-        if ((sender as Button)?.Tag is Chapter chapter)
+        if ((sender as FrameworkElement)?.Tag is Chapter chapter)
         {
-            var input = Microsoft.VisualBasic.Interaction.InputBox("Rename chapter", "Rename", chapter.Title);
-            if (!string.IsNullOrWhiteSpace(input))
+            var item = ChapterTree.ItemContainerGenerator.ContainerFromItem(chapter) as TreeViewItem;
+            if (item == null) return;
+            var textBox = FindVisualChild<TextBox>(item, "ChapterEditBox");
+            var textBlock = FindVisualChild<TextBlock>(item, "ChapterText");
+            if (textBox != null && textBlock != null)
             {
-                chapter.Title = input;
-                ProjectService.CurrentProject.IsDirty = true;
+                textBox.Text = chapter.Title;
+                textBox.Tag = textBlock;
+                textBlock.Visibility = Visibility.Collapsed;
+                textBox.Visibility = Visibility.Visible;
+                textBox.Focus();
+                textBox.SelectAll();
             }
         }
     }
 
     private void RenameScene_Click(object sender, RoutedEventArgs e)
     {
-        if ((sender as Button)?.Tag is Scene scene)
+        if ((sender as FrameworkElement)?.Tag is Scene scene)
         {
-            var input = Microsoft.VisualBasic.Interaction.InputBox("Rename scene", "Rename", scene.Title);
-            if (!string.IsNullOrWhiteSpace(input))
+            foreach (var ch in ProjectService.CurrentProject.Chapters)
             {
-                scene.Title = input;
-                ProjectService.CurrentProject.IsDirty = true;
+                if (ch.Scenes.Contains(scene))
+                {
+                    var chapterItem = ChapterTree.ItemContainerGenerator.ContainerFromItem(ch) as TreeViewItem;
+                    chapterItem?.UpdateLayout();
+                    var sceneItem = chapterItem?.ItemContainerGenerator.ContainerFromItem(scene) as TreeViewItem;
+                    if (sceneItem == null) return;
+                    var textBox = FindVisualChild<TextBox>(sceneItem, "SceneEditBox");
+                    var textBlock = FindVisualChild<TextBlock>(sceneItem, "SceneText");
+                    if (textBox != null && textBlock != null)
+                    {
+                        textBox.Text = scene.Title;
+                        textBox.Tag = textBlock;
+                        textBlock.Visibility = Visibility.Collapsed;
+                        textBox.Visibility = Visibility.Visible;
+                        textBox.Focus();
+                        textBox.SelectAll();
+                    }
+                    break;
+                }
             }
         }
     }
@@ -192,22 +216,100 @@ public partial class TranscriptView : UserControl
         UpdateCounts();
     }
 
-    private void OpenChapterMenu(object sender, RoutedEventArgs e)
+    private void OpenItemMenu(object sender, RoutedEventArgs e)
     {
-        if (sender is Button btn && btn.ContextMenu != null)
+        if (sender is Button btn)
         {
-            btn.ContextMenu.PlacementTarget = btn;
-            btn.ContextMenu.IsOpen = true;
+            var item = FindParent<TreeViewItem>(btn);
+            if (item?.ContextMenu != null)
+            {
+                item.ContextMenu.PlacementTarget = btn;
+                item.ContextMenu.IsOpen = true;
+            }
         }
     }
 
-    private void OpenSceneMenu(object sender, RoutedEventArgs e)
+    private void ChapterTree_PreviewMouseRightButtonDown(object sender, MouseButtonEventArgs e)
     {
-        if (sender is Button btn && btn.ContextMenu != null)
+        var item = FindParent<TreeViewItem>(e.OriginalSource as DependencyObject);
+        if (item != null)
         {
-            btn.ContextMenu.PlacementTarget = btn;
-            btn.ContextMenu.IsOpen = true;
+            e.Handled = true;
+            if (item.ContextMenu != null)
+            {
+                item.ContextMenu.PlacementTarget = item;
+                item.ContextMenu.IsOpen = true;
+            }
         }
+    }
+
+    private void RenameBox_KeyDown(object sender, KeyEventArgs e)
+    {
+        if (sender is TextBox tb)
+        {
+            if (e.Key == Key.Enter)
+            {
+                FinishRename(tb, true);
+                e.Handled = true;
+            }
+            else if (e.Key == Key.Escape)
+            {
+                FinishRename(tb, false);
+                e.Handled = true;
+            }
+        }
+    }
+
+    private void RenameBox_LostFocus(object sender, RoutedEventArgs e)
+    {
+        if (sender is TextBox tb && tb.Visibility == Visibility.Visible)
+        {
+            FinishRename(tb, true);
+        }
+    }
+
+    private void FinishRename(TextBox tb, bool commit)
+    {
+        var textBlock = tb.Tag as TextBlock;
+        if (textBlock != null)
+            textBlock.Visibility = Visibility.Visible;
+        tb.Visibility = Visibility.Collapsed;
+
+        if (commit)
+        {
+            if (tb.DataContext is Chapter ch)
+            {
+                ch.Title = tb.Text;
+            }
+            else if (tb.DataContext is Scene sc)
+            {
+                sc.Title = tb.Text;
+            }
+            ProjectService.CurrentProject.IsDirty = true;
+        }
+    }
+
+    private static T? FindParent<T>(DependencyObject? current) where T : DependencyObject
+    {
+        while (current != null && current is not T)
+        {
+            current = VisualTreeHelper.GetParent(current);
+        }
+        return current as T;
+    }
+
+    private static T? FindVisualChild<T>(DependencyObject parent, string name) where T : FrameworkElement
+    {
+        for (int i = 0; i < VisualTreeHelper.GetChildrenCount(parent); i++)
+        {
+            var child = VisualTreeHelper.GetChild(parent, i);
+            if (child is T fe && fe.Name == name)
+                return fe;
+            var result = FindVisualChild<T>(child, name);
+            if (result != null)
+                return result;
+        }
+        return null;
     }
 
     private void Editor_TextChanged(object sender, TextChangedEventArgs e)


### PR DESCRIPTION
## Summary
- Restyle chapter/scene sidebar for dark theme with trimmed titles and overflow menus
- Add inline renaming, hover/selection menu buttons, and shared context menus
- Preserve selection when opening menus and support keyboard/menu accessibility

## Testing
- `/root/.dotnet/dotnet build WordForge.sln`

------
https://chatgpt.com/codex/tasks/task_e_68a5445ed9548330ad2c0d42e09c15f8