### PR TITLE
Bind chapter and scene titles to model

### DIFF
--- a/WordForge/TranscriptModels.cs
+++ b/WordForge/TranscriptModels.cs
@@ -1,15 +1,65 @@
 using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
 
 namespace WordForge;
 
-public class Scene
+public class Scene : INotifyPropertyChanged
 {
-    public string Title { get; set; } = "Scene";
-    public string Text { get; set; } = string.Empty;
+    private string _title = "Scene";
+    private string _text = string.Empty;
+
+    public string Title
+    {
+        get => _title;
+        set
+        {
+            if (_title != value)
+            {
+                _title = value;
+                OnPropertyChanged();
+            }
+        }
+    }
+
+    public string Text
+    {
+        get => _text;
+        set
+        {
+            if (_text != value)
+            {
+                _text = value;
+                OnPropertyChanged();
+            }
+        }
+    }
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+    private void OnPropertyChanged([CallerMemberName] string? name = null) =>
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
 }
 
-public class Chapter
+public class Chapter : INotifyPropertyChanged
 {
-    public string Title { get; set; } = "Chapter";
+    private string _title = "Chapter";
+
+    public string Title
+    {
+        get => _title;
+        set
+        {
+            if (_title != value)
+            {
+                _title = value;
+                OnPropertyChanged();
+            }
+        }
+    }
+
     public ObservableCollection<Scene> Scenes { get; set; } = new();
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+    private void OnPropertyChanged([CallerMemberName] string? name = null) =>
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
 }

--- a/WordForge/views/TranscriptView.xaml
+++ b/WordForge/views/TranscriptView.xaml
@@ -86,7 +86,7 @@
                                         <ColumnDefinition Width="*"/>
                                         <ColumnDefinition Width="Auto"/>
                                     </Grid.ColumnDefinitions>
-                                    <TextBlock x:Name="ChapterText" Grid.Column="0" Text="{Binding Title}" TextTrimming="CharacterEllipsis" ToolTip="{Binding Title}" VerticalAlignment="Center">
+                                    <TextBlock x:Name="ChapterText" Grid.Column="0" Text="{Binding Title, Mode=OneWay}" TextTrimming="CharacterEllipsis" ToolTip="{Binding Title}" VerticalAlignment="Center">
                                     <TextBlock.Style>
                                         <Style TargetType="TextBlock">
                                             <Setter Property="Foreground" Value="#FFE5E7EB"/>
@@ -98,7 +98,7 @@
                                         </Style>
                                     </TextBlock.Style>
                                 </TextBlock>
-                                    <TextBox x:Name="ChapterEditBox" Grid.Column="0" Text="{Binding Title, UpdateSourceTrigger=Explicit}" Visibility="Collapsed" Background="#FF26282C" Foreground="#FFE5E7EB" BorderBrush="#FF3B3F45" BorderThickness="1" KeyDown="RenameBox_KeyDown" LostFocus="RenameBox_LostFocus"/>
+                                    <TextBox x:Name="ChapterEditBox" Grid.Column="0" Text="{Binding Title, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Visibility="Collapsed" Background="#FF26282C" Foreground="#FFE5E7EB" BorderBrush="#FF3B3F45" BorderThickness="1" KeyDown="RenameBox_KeyDown" LostFocus="RenameBox_LostFocus"/>
                                     <Button x:Name="ChapterMenuButton" Grid.Column="1" Content="⋮" Width="20" Height="20" Margin="0" Click="OpenItemMenu" Visibility="Hidden" Focusable="True">
                                         <Button.Style>
                                             <Style TargetType="Button">
@@ -138,7 +138,7 @@
                                         <ColumnDefinition Width="*"/>
                                         <ColumnDefinition Width="Auto"/>
                                     </Grid.ColumnDefinitions>
-                                    <TextBlock x:Name="SceneText" Grid.Column="0" Text="{Binding Title}" TextTrimming="CharacterEllipsis" ToolTip="{Binding Title}" VerticalAlignment="Center">
+                                    <TextBlock x:Name="SceneText" Grid.Column="0" Text="{Binding Title, Mode=OneWay}" TextTrimming="CharacterEllipsis" ToolTip="{Binding Title}" VerticalAlignment="Center">
                                     <TextBlock.Style>
                                         <Style TargetType="TextBlock">
                                             <Setter Property="Foreground" Value="#FFE5E7EB"/>
@@ -150,7 +150,7 @@
                                         </Style>
                                     </TextBlock.Style>
                                 </TextBlock>
-                                    <TextBox x:Name="SceneEditBox" Grid.Column="0" Text="{Binding Title, UpdateSourceTrigger=Explicit}" Visibility="Collapsed" Background="#FF26282C" Foreground="#FFE5E7EB" BorderBrush="#FF3B3F45" BorderThickness="1" KeyDown="RenameBox_KeyDown" LostFocus="RenameBox_LostFocus"/>
+                                    <TextBox x:Name="SceneEditBox" Grid.Column="0" Text="{Binding Title, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Visibility="Collapsed" Background="#FF26282C" Foreground="#FFE5E7EB" BorderBrush="#FF3B3F45" BorderThickness="1" KeyDown="RenameBox_KeyDown" LostFocus="RenameBox_LostFocus"/>
                                     <Button x:Name="SceneMenuButton" Grid.Column="1" Content="⋮" Width="20" Height="20" Margin="0" Click="OpenItemMenu" Visibility="Hidden" Focusable="True">
                                         <Button.Style>
                                             <Style TargetType="Button">

--- a/WordForge/views/TranscriptView.xaml.cs
+++ b/WordForge/views/TranscriptView.xaml.cs
@@ -37,6 +37,18 @@ public partial class TranscriptView : UserControl
         public string EditorText { get; set; } = string.Empty;
     }
 
+    private class RenameState
+    {
+        public TextBlock TextBlock { get; }
+        public string OriginalTitle { get; }
+
+        public RenameState(TextBlock textBlock, string originalTitle)
+        {
+            TextBlock = textBlock;
+            OriginalTitle = originalTitle;
+        }
+    }
+
     private static readonly Regex SceneBreakRegex = new("^\\s*\\*{3,}\\s*$", RegexOptions.Compiled | RegexOptions.Multiline);
 
     public TranscriptView()
@@ -124,8 +136,7 @@ public partial class TranscriptView : UserControl
             var textBlock = FindVisualChild<TextBlock>(item, "ChapterText");
             if (textBox != null && textBlock != null)
             {
-                textBox.Text = chapter.Title;
-                textBox.Tag = textBlock;
+                textBox.Tag = new RenameState(textBlock, chapter.Title);
                 textBlock.Visibility = Visibility.Collapsed;
                 textBox.Visibility = Visibility.Visible;
                 textBox.Focus();
@@ -150,8 +161,7 @@ public partial class TranscriptView : UserControl
                     var textBlock = FindVisualChild<TextBlock>(sceneItem, "SceneText");
                     if (textBox != null && textBlock != null)
                     {
-                        textBox.Text = scene.Title;
-                        textBox.Tag = textBlock;
+                        textBox.Tag = new RenameState(textBlock, scene.Title);
                         textBlock.Visibility = Visibility.Collapsed;
                         textBox.Visibility = Visibility.Visible;
                         textBox.Focus();
@@ -306,23 +316,27 @@ public partial class TranscriptView : UserControl
 
     private void FinishRename(TextBox tb, bool commit)
     {
-        var textBlock = tb.Tag as TextBlock;
-        if (textBlock != null)
-            textBlock.Visibility = Visibility.Visible;
+        if (tb.Tag is RenameState state)
+        {
+            state.TextBlock.Visibility = Visibility.Visible;
+            if (!commit)
+            {
+                if (tb.DataContext is Chapter ch)
+                    ch.Title = state.OriginalTitle;
+                else if (tb.DataContext is Scene sc)
+                    sc.Title = state.OriginalTitle;
+            }
+        }
+
         tb.Visibility = Visibility.Collapsed;
 
         if (commit)
         {
-            if (tb.DataContext is Chapter ch)
-            {
-                ch.Title = tb.Text;
-            }
-            else if (tb.DataContext is Scene sc)
-            {
-                sc.Title = tb.Text;
-            }
             ProjectService.CurrentProject.IsDirty = true;
         }
+
+        SelectItem(tb.DataContext);
+        tb.Tag = null;
     }
 
     private static T? FindParent<T>(DependencyObject? current) where T : DependencyObject


### PR DESCRIPTION
## Summary
- Implement INotifyPropertyChanged for Chapter and Scene models so title and text changes propagate
- Bind TextBlocks and edit TextBoxes to Title with one-way and two-way bindings for live updates
- Simplify rename workflow to rely on bindings and keep selection on the edited item

## Testing
- `dotnet build` *(fails: NETSDK1045 – The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68a632d2d8f483309fa391be5ffdf311