### PR TITLE
Add autosave settings and forge file save/load

### DIFF
--- a/WordForge/AutosaveService.cs
+++ b/WordForge/AutosaveService.cs
@@ -1,0 +1,71 @@
+using System;
+using System.IO;
+using System.Timers;
+using System.Windows;
+
+namespace WordForge;
+
+public static class AutosaveService
+{
+    private static Timer? _timer;
+    private static DateTime _lastPaneSave = DateTime.MinValue;
+
+    public static void Configure(Project project)
+    {
+        _timer?.Stop();
+        _timer?.Dispose();
+        _timer = null;
+        RightPaneService.PaneChanged -= PaneChanged;
+
+        if (!project.Autosave.Enabled)
+            return;
+
+        if (project.Autosave.Mode == AutosaveMode.Interval)
+        {
+            _timer = new Timer(Math.Max(1, project.Autosave.Minutes) * 60 * 1000);
+            _timer.Elapsed += (_, __) => Application.Current.Dispatcher.Invoke(SaveAutosave);
+            _timer.AutoReset = true;
+            _timer.Start();
+        }
+        else
+        {
+            _lastPaneSave = DateTime.MinValue;
+            RightPaneService.PaneChanged += PaneChanged;
+        }
+    }
+
+    private static void PaneChanged(RightPaneKind kind)
+    {
+        if ((DateTime.UtcNow - _lastPaneSave).TotalSeconds < 5)
+            return;
+        _lastPaneSave = DateTime.UtcNow;
+        SaveAutosave();
+    }
+
+    private static void SaveAutosave()
+    {
+        if (ProjectService.CurrentPath == null)
+            return;
+        var path = ProjectService.GetAutosavePath(ProjectService.CurrentPath);
+        try
+        {
+            ProjectService.SaveCopy(ProjectService.CurrentProject, path);
+        }
+        catch
+        {
+            // ignore
+        }
+    }
+
+    public static void OnManualSave()
+    {
+        if (ProjectService.CurrentPath == null)
+            return;
+        var path = ProjectService.GetAutosavePath(ProjectService.CurrentPath);
+        if (File.Exists(path))
+        {
+            try { File.Delete(path); } catch { }
+        }
+    }
+}
+

--- a/WordForge/ProjectService.cs
+++ b/WordForge/ProjectService.cs
@@ -1,21 +1,38 @@
 using System;
 using System.IO;
+using System.Text;
 using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.IO.Compression;
 using System.Windows;
 using Microsoft.Win32;
 using System.Collections.ObjectModel;
+using System.Linq;
 
 namespace WordForge;
+
+public enum AutosaveMode
+{
+    Interval,
+    OnPaneChange
+}
+
+public record AutosaveSettings
+{
+    public bool Enabled { get; set; }
+    public AutosaveMode Mode { get; set; } = AutosaveMode.Interval;
+    public int Minutes { get; set; } = 5;
+}
 
 public record Project
 {
     public string Title { get; set; } = "";
     public string Author { get; set; } = "";
     public string Genre { get; set; } = "";
-    public DateTime Created { get; set; }
-        = DateTime.Now;
-    public DateTime Saved { get; set; }
-        = DateTime.Now;
+    public DateTime CreatedUtc { get; set; } = DateTime.UtcNow;
+    public DateTime ModifiedUtc { get; set; } = DateTime.UtcNow;
+    public bool Transitions { get; set; } = true;
+    public AutosaveSettings Autosave { get; set; } = new();
     public ObservableCollection<Chapter> Chapters { get; set; } = new();
     public bool IsDirty { get; set; } = false;
 }
@@ -26,12 +43,11 @@ public static class ProjectService
     public static Project CurrentProject { get; private set; } = new Project
     {
         Title = "New Project",
-        Created = DateTime.Now,
-        Saved = DateTime.Now
+        CreatedUtc = DateTime.UtcNow,
+        ModifiedUtc = DateTime.UtcNow
     };
 
-    public static string? CurrentPath { get; private set; }
-        = null;
+    public static string? CurrentPath { get; private set; } = null;
 
     public static void CreateNew(Project project, string? directory)
     {
@@ -41,7 +57,7 @@ public static class ProjectService
         Directory.CreateDirectory(directory);
         var fileName = SanitizeFileName(project.Title) + ".forge";
         var path = Path.Combine(directory, fileName);
-        project.Created = project.Saved = DateTime.Now;
+        project.CreatedUtc = project.ModifiedUtc = DateTime.UtcNow;
         SaveProject(project, path);
     }
 
@@ -88,7 +104,7 @@ public static class ProjectService
                 : Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments),
             FileName = CurrentPath != null
                 ? Path.GetFileName(CurrentPath)
-                : SanitizeFileName(CurrentProject.Title) + ".forge"
+                : SanitizeFileName(CurrentProject.Title) + ".forge",
         };
         if (dialog.ShowDialog() == true)
         {
@@ -106,21 +122,220 @@ public static class ProjectService
         };
         if (dialog.ShowDialog() == true)
         {
-            var json = File.ReadAllText(dialog.FileName);
-            var project = JsonSerializer.Deserialize<Project>(json);
-            if (project != null)
+            var path = dialog.FileName;
+            var autosave = GetAutosavePath(path);
+            if (File.Exists(autosave) && File.GetLastWriteTime(autosave) > File.GetLastWriteTime(path))
             {
-                SetCurrent(project, dialog.FileName);
+                if (MessageBox.Show("A newer autosave exists. Recover?", "Autosave", MessageBoxButton.YesNo) == MessageBoxResult.Yes)
+                {
+                    try
+                    {
+                        var proj = LoadFromPath(autosave);
+                        if (proj != null)
+                        {
+                            SetCurrent(proj, path);
+                            CurrentProject.IsDirty = true;
+                            return;
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        MessageBox.Show(ex.Message, "Load", MessageBoxButton.OK, MessageBoxImage.Error);
+                    }
+                }
+            }
+            try
+            {
+                var project = LoadFromPath(path);
+                if (project != null)
+                {
+                    SetCurrent(project, path);
+                }
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show(ex.Message, "Load", MessageBoxButton.OK, MessageBoxImage.Error);
             }
         }
     }
 
-    private static void SaveToPath(Project project, string path)
+    internal static void SaveToPath(Project project, string path, bool markClean = true)
     {
-        project.Saved = DateTime.Now;
-        var json = JsonSerializer.Serialize(project, new JsonSerializerOptions { WriteIndented = true });
-        File.WriteAllText(path, json);
-        project.IsDirty = false;
+        project.ModifiedUtc = DateTime.UtcNow;
+        var temp = path + ".tmp";
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        using (var fs = new FileStream(temp, FileMode.Create, FileAccess.Write, FileShare.None))
+        using (var archive = new ZipArchive(fs, ZipArchiveMode.Create))
+        {
+            var projectEntry = archive.CreateEntry("project.json");
+            using (var writer = new StreamWriter(projectEntry.Open(), new UTF8Encoding(false)))
+            {
+                writer.NewLine = "\n";
+                var json = JsonSerializer.Serialize(new
+                {
+                    schemaVersion = 1,
+                    title = project.Title,
+                    author = project.Author,
+                    genre = project.Genre,
+                    autosave = project.Autosave,
+                    transitions = project.Transitions,
+                    createdUtc = project.CreatedUtc,
+                    modifiedUtc = project.ModifiedUtc
+                }, new JsonSerializerOptions { WriteIndented = true });
+                writer.Write(json);
+            }
+
+            var indexEntry = archive.CreateEntry("transcript/index.json");
+            using (var writer = new StreamWriter(indexEntry.Open(), new UTF8Encoding(false)))
+            {
+                writer.NewLine = "\n";
+                var index = project.Chapters.Select(c => new { id = c.Id, title = c.Title }).ToList();
+                var json = JsonSerializer.Serialize(index, new JsonSerializerOptions { WriteIndented = true });
+                writer.Write(json);
+            }
+
+            foreach (var ch in project.Chapters)
+            {
+                ch.UpdatedUtc = DateTime.UtcNow;
+                var entry = archive.CreateEntry($"transcript/chapters/ch_{ch.Id}.json");
+                using var writer = new StreamWriter(entry.Open(), new UTF8Encoding(false));
+                writer.NewLine = "\n";
+                var obj = new
+                {
+                    id = ch.Id,
+                    title = ch.Title,
+                    createdUtc = ch.CreatedUtc,
+                    updatedUtc = ch.UpdatedUtc,
+                    scenes = ch.Scenes.Select(s => new { title = s.Title, text = s.Text }).ToList()
+                };
+                var json = JsonSerializer.Serialize(obj, new JsonSerializerOptions { WriteIndented = true });
+                writer.Write(json);
+            }
+
+            CreateEmpty(archive, "bibles/characters/index.json", "[]");
+            archive.CreateEntry("bibles/characters/entries/");
+            CreateEmpty(archive, "bibles/locations/index.json", "[]");
+            archive.CreateEntry("bibles/locations/entries/");
+            CreateEmpty(archive, "bibles/items/index.json", "[]");
+            archive.CreateEntry("bibles/items/entries/");
+            CreateEmpty(archive, "bibles/lore/index.json", "[]");
+            archive.CreateEntry("bibles/lore/entries/");
+            CreateEmpty(archive, "outline/outline.json", "{}");
+            CreateEmpty(archive, "timeline/timeline.json", "{}");
+            archive.CreateEntry("assets/");
+        }
+
+        if (File.Exists(path))
+            File.Delete(path);
+        File.Move(temp, path);
+
+        if (markClean)
+            project.IsDirty = false;
+    }
+
+    private static void CreateEmpty(ZipArchive archive, string path, string content)
+    {
+        var entry = archive.CreateEntry(path);
+        using var writer = new StreamWriter(entry.Open(), new UTF8Encoding(false));
+        writer.NewLine = "\n";
+        writer.Write(content);
+    }
+
+    private static Project? LoadFromPath(string path)
+    {
+        using var archive = ZipFile.OpenRead(path);
+        var projectEntry = archive.GetEntry("project.json") ?? throw new FileNotFoundException("project.json missing");
+        Project? project;
+        using (var reader = new StreamReader(projectEntry.Open()))
+        {
+            var json = reader.ReadToEnd();
+            var doc = JsonSerializer.Deserialize<ProjectFile>(json);
+            if (doc == null) return null;
+            project = new Project
+            {
+                Title = doc.title ?? "",
+                Author = doc.author ?? "",
+                Genre = doc.genre ?? "",
+                CreatedUtc = doc.createdUtc,
+                ModifiedUtc = doc.modifiedUtc,
+                Transitions = doc.transitions,
+                Autosave = doc.autosave ?? new AutosaveSettings()
+            };
+        }
+
+        var indexEntry = archive.GetEntry("transcript/index.json");
+        List<ChapterIndex> index = new();
+        if (indexEntry != null)
+        {
+            using var reader = new StreamReader(indexEntry.Open());
+            var json = reader.ReadToEnd();
+            index = JsonSerializer.Deserialize<List<ChapterIndex>>(json) ?? new();
+        }
+        else
+        {
+            index = archive.Entries.Where(e => e.FullName.StartsWith("transcript/chapters/ch_") && e.FullName.EndsWith(".json"))
+                .Select(e =>
+                {
+                    using var r = new StreamReader(e.Open());
+                    var ch = JsonSerializer.Deserialize<ChapterFile>(r.ReadToEnd());
+                    return ch != null ? new ChapterIndex { id = ch.id, title = ch.title } : null;
+                })
+                .Where(i => i != null)
+                .Cast<ChapterIndex>()
+                .ToList();
+        }
+
+        foreach (var idx in index)
+        {
+            try
+            {
+                var entry = archive.GetEntry($"transcript/chapters/ch_{idx.id}.json");
+                if (entry == null) continue;
+                using var reader = new StreamReader(entry.Open());
+                var json = reader.ReadToEnd();
+                var file = JsonSerializer.Deserialize<ChapterFile>(json);
+                if (file == null) continue;
+                var chapter = new Chapter
+                {
+                    Id = file.id ?? Guid.NewGuid().ToString(),
+                    Title = file.title ?? "Chapter",
+                    CreatedUtc = file.createdUtc,
+                    UpdatedUtc = file.updatedUtc
+                };
+                foreach (var s in file.scenes ?? new List<SceneFile>())
+                    chapter.Scenes.Add(new Scene { Title = s.title ?? "Scene", Text = s.text ?? string.Empty });
+                project.Chapters.Add(chapter);
+            }
+            catch
+            {
+                // skip malformed chapter
+            }
+        }
+
+        return project;
+    }
+
+    private class ProjectFile
+    {
+        public int schemaVersion { get; set; }
+        public string? title { get; set; }
+        public string? author { get; set; }
+        public string? genre { get; set; }
+        public AutosaveSettings? autosave { get; set; }
+        public bool transitions { get; set; }
+        [JsonPropertyName("createdUtc")] public DateTime createdUtc { get; set; }
+        [JsonPropertyName("modifiedUtc")] public DateTime modifiedUtc { get; set; }
+    }
+
+    private class ChapterIndex { public string id { get; set; } = ""; public string title { get; set; } = ""; }
+    private class SceneFile { public string? title { get; set; } public string? text { get; set; } }
+    private class ChapterFile
+    {
+        public string? id { get; set; }
+        public string? title { get; set; }
+        public DateTime createdUtc { get; set; }
+        public DateTime updatedUtc { get; set; }
+        public List<SceneFile>? scenes { get; set; }
     }
 
     private static void SetCurrent(Project project, string path)
@@ -128,7 +343,9 @@ public static class ProjectService
         CurrentProject = project;
         CurrentPath = path;
         CurrentProject.IsDirty = false;
+        TransitionService.TransitionsEnabled = project.Transitions;
         UpdateWindowTitle();
+        AutosaveService.Configure(project);
     }
 
     private static void UpdateWindowTitle()
@@ -155,6 +372,16 @@ public static class ProjectService
             path += ".forge";
         SaveToPath(project, path);
         SetCurrent(project, path);
+        AutosaveService.OnManualSave();
     }
+
+    internal static string GetAutosavePath(string path)
+    {
+        var dir = Path.GetDirectoryName(path)!;
+        var file = Path.GetFileNameWithoutExtension(path) + ".autosave.forge";
+        return Path.Combine(dir, file);
+    }
+
+    public static void SaveCopy(Project project, string path) => SaveToPath(project, path, false);
 }
 

--- a/WordForge/PropertiesWindow.xaml
+++ b/WordForge/PropertiesWindow.xaml
@@ -50,6 +50,23 @@
                     <ToggleButton x:Name="TransitionsToggle" Style="{StaticResource ToggleSwitchStyle}" Width="50" Height="24"/>
                     <TextBlock x:Name="ToggleStateText" Foreground="#FFE5E7EB" VerticalAlignment="Center" Margin="8,0,0,0"/>
                 </StackPanel>
+                <StackPanel Margin="0,0,0,10">
+                    <StackPanel Orientation="Horizontal" VerticalAlignment="Center" Margin="0,0,0,4">
+                        <TextBlock Text="Autosave:" Foreground="#FFE5E7EB" VerticalAlignment="Center" Margin="0,0,8,0"/>
+                        <ToggleButton x:Name="AutosaveToggle" Style="{StaticResource ToggleSwitchStyle}" Width="50" Height="24" ToolTip="Enable automatic saving"/>
+                        <TextBlock x:Name="AutosaveStateText" Foreground="#FFE5E7EB" VerticalAlignment="Center" Margin="8,0,0,0"/>
+                    </StackPanel>
+                    <StackPanel Orientation="Horizontal" Margin="0,0,0,0">
+                        <ComboBox x:Name="AutosaveModeBox" Width="140" ToolTip="Choose when autosave occurs">
+                            <ComboBoxItem>Every N minutes</ComboBoxItem>
+                            <ComboBoxItem>On pane change</ComboBoxItem>
+                        </ComboBox>
+                        <StackPanel Orientation="Horizontal" Margin="8,0,0,0" x:Name="AutosaveMinutesPanel">
+                            <TextBlock Text="Minutes:" Foreground="#FFE5E7EB" VerticalAlignment="Center"/>
+                            <TextBox x:Name="AutosaveMinutesBox" Width="40" Margin="4,0,0,0" ToolTip="Interval in minutes"/>
+                        </StackPanel>
+                    </StackPanel>
+                </StackPanel>
                 <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
                     <Button Width="100" Content="Save Changes" Click="Save_Click"/>
                 </StackPanel>

--- a/WordForge/PropertiesWindow.xaml.cs
+++ b/WordForge/PropertiesWindow.xaml.cs
@@ -22,17 +22,42 @@ public partial class PropertiesWindow : Window
             : Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
         LocationBox.Text = location;
 
-        TransitionsToggle.IsChecked = TransitionService.TransitionsEnabled;
-        ToggleStateText.Text = TransitionService.TransitionsEnabled ? "On" : "Off";
+        TransitionsToggle.IsChecked = project.Transitions;
+        ToggleStateText.Text = project.Transitions ? "On" : "Off";
         TransitionsToggle.Checked += ToggleChanged;
         TransitionsToggle.Unchecked += ToggleChanged;
+
+        AutosaveToggle.IsChecked = project.Autosave.Enabled;
+        AutosaveStateText.Text = project.Autosave.Enabled ? "On" : "Off";
+        AutosaveToggle.Checked += AutosaveToggleChanged;
+        AutosaveToggle.Unchecked += AutosaveToggleChanged;
+        AutosaveModeBox.SelectedIndex = project.Autosave.Mode == AutosaveMode.Interval ? 0 : 1;
+        AutosaveMinutesBox.Text = project.Autosave.Minutes.ToString();
+        AutosaveModeBox.SelectionChanged += (_, __) => UpdateAutosaveVisibility();
+        UpdateAutosaveVisibility();
     }
 
     private void ToggleChanged(object? sender, RoutedEventArgs e)
     {
         bool enabled = TransitionsToggle.IsChecked == true;
         TransitionService.TransitionsEnabled = enabled;
+        ProjectService.CurrentProject.Transitions = enabled;
         ToggleStateText.Text = enabled ? "On" : "Off";
+    }
+
+    private void AutosaveToggleChanged(object? sender, RoutedEventArgs e)
+    {
+        bool enabled = AutosaveToggle.IsChecked == true;
+        AutosaveStateText.Text = enabled ? "On" : "Off";
+        UpdateAutosaveVisibility();
+    }
+
+    private void UpdateAutosaveVisibility()
+    {
+        if (AutosaveToggle.IsChecked == true && AutosaveModeBox.SelectedIndex == 0)
+            AutosaveMinutesPanel.Visibility = Visibility.Visible;
+        else
+            AutosaveMinutesPanel.Visibility = Visibility.Collapsed;
     }
 
     private void Save_Click(object sender, RoutedEventArgs e)
@@ -41,6 +66,11 @@ public partial class PropertiesWindow : Window
         project.Title = TitleBox.Text.Trim();
         project.Author = AuthorBox.Text.Trim();
         project.Genre = GenreBox.SelectedItem?.ToString() ?? "";
+        project.Transitions = TransitionsToggle.IsChecked == true;
+        project.Autosave.Enabled = AutosaveToggle.IsChecked == true;
+        project.Autosave.Mode = AutosaveModeBox.SelectedIndex == 0 ? AutosaveMode.Interval : AutosaveMode.OnPaneChange;
+        if (int.TryParse(AutosaveMinutesBox.Text, out int mins))
+            project.Autosave.Minutes = mins;
 
         var directory = string.IsNullOrWhiteSpace(LocationBox.Text)
             ? Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments)

--- a/WordForge/TranscriptModels.cs
+++ b/WordForge/TranscriptModels.cs
@@ -1,6 +1,7 @@
 using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
+using System;
 
 namespace WordForge;
 
@@ -43,6 +44,10 @@ public class Scene : INotifyPropertyChanged
 public class Chapter : INotifyPropertyChanged
 {
     private string _title = "Chapter";
+
+    public string Id { get; set; } = Guid.NewGuid().ToString();
+    public DateTime CreatedUtc { get; set; } = DateTime.UtcNow;
+    public DateTime UpdatedUtc { get; set; } = DateTime.UtcNow;
 
     public string Title
     {


### PR DESCRIPTION
## Summary
- Add autosave controls in the Properties window and bind them to project settings
- Introduce AutosaveService and extend ProjectService to manage autosave behavior
- Replace project saving/loading with ZIP-based .forge container including transcripts and scaffolds

## Testing
- `dotnet build WordForge/WordForge/WordForge.csproj` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68a63ceaffe48330b68fbf7892f50c89