### PR TITLE
Add Lore Bible support and startup workflow improvements

### DIFF
--- a/WordForge/App.xaml
+++ b/WordForge/App.xaml
@@ -1,8 +1,7 @@
 ﻿<Application x:Class="WordForge.App"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:local="clr-namespace:WordForge"
-             StartupUri="MainWindow.xaml">
+             xmlns:local="clr-namespace:WordForge">
     <Application.Resources>
          
     </Application.Resources>

--- a/WordForge/App.xaml.cs
+++ b/WordForge/App.xaml.cs
@@ -1,14 +1,34 @@
-﻿using System.Configuration;
-using System.Data;
 using System.Windows;
 
-namespace WordForge
-{
-    /// <summary>
-    /// Interaction logic for App.xaml
-    /// </summary>
-    public partial class App : Application
-    {
-    }
+namespace WordForge;
 
+public partial class App : Application
+{
+    protected override void OnStartup(StartupEventArgs e)
+    {
+        base.OnStartup(e);
+
+        var window = new NewProjectWindow();
+        if (window.ShowDialog() == true)
+        {
+            var main = new MainWindow();
+            MainWindow = main;
+            if (!window.IsLoad)
+            {
+                var project = new Project
+                {
+                    Title = window.ProjectTitle,
+                    Author = window.ProjectAuthor,
+                    Genre = window.ProjectGenre
+                };
+                ProjectService.CreateNew(project, window.ProjectLocation);
+            }
+            main.Show();
+            ProjectService.InitializeUI();
+        }
+        else
+        {
+            Shutdown();
+        }
+    }
 }

--- a/WordForge/CustomizeWindow.xaml
+++ b/WordForge/CustomizeWindow.xaml
@@ -1,0 +1,43 @@
+<Window x:Class="WordForge.CustomizeWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Customize Panes" Width="1000" Height="700"
+        WindowStartupLocation="CenterOwner" Background="#FF1A1B1E" FontFamily="Segoe UI">
+    <TabControl TabStripPlacement="Left" Background="#FF1A1B1E" Foreground="#FFE5E7EB">
+        <TabItem Header="Transcript">
+            <Grid Background="#FF232529">
+                <TextBlock Text="Transcript customization" Foreground="#FFE5E7EB" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+            </Grid>
+        </TabItem>
+        <TabItem Header="Timeline">
+            <Grid Background="#FF232529">
+                <TextBlock Text="Timeline customization" Foreground="#FFE5E7EB" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+            </Grid>
+        </TabItem>
+        <TabItem Header="Outline">
+            <Grid Background="#FF232529">
+                <TextBlock Text="Outline customization" Foreground="#FFE5E7EB" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+            </Grid>
+        </TabItem>
+        <TabItem Header="Character Bible">
+            <Grid Background="#FF232529">
+                <TextBlock Text="Character Bible customization" Foreground="#FFE5E7EB" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+            </Grid>
+        </TabItem>
+        <TabItem Header="Location Bible">
+            <Grid Background="#FF232529">
+                <TextBlock Text="Location Bible customization" Foreground="#FFE5E7EB" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+            </Grid>
+        </TabItem>
+        <TabItem Header="Item Bible">
+            <Grid Background="#FF232529">
+                <TextBlock Text="Item Bible customization" Foreground="#FFE5E7EB" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+            </Grid>
+        </TabItem>
+        <TabItem Header="Lore Bible">
+            <Grid Background="#FF232529">
+                <TextBlock Text="Lore Bible customization" Foreground="#FFE5E7EB" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+            </Grid>
+        </TabItem>
+    </TabControl>
+</Window>

--- a/WordForge/CustomizeWindow.xaml.cs
+++ b/WordForge/CustomizeWindow.xaml.cs
@@ -1,0 +1,11 @@
+using System.Windows;
+
+namespace WordForge;
+
+public partial class CustomizeWindow : Window
+{
+    public CustomizeWindow()
+    {
+        InitializeComponent();
+    }
+}

--- a/WordForge/NewProjectWindow.xaml
+++ b/WordForge/NewProjectWindow.xaml
@@ -1,30 +1,42 @@
 <Window x:Class="WordForge.NewProjectWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        Title="New Project" SizeToContent="WidthAndHeight"
+        Title="New Project" Width="800" Height="400"
         WindowStartupLocation="CenterOwner" ResizeMode="NoResize"
         Background="#FF1A1B1E" FontFamily="Segoe UI">
-    <StackPanel Margin="20" Width="320">
-        <StackPanel Orientation="Horizontal" Margin="0,0,0,10">
-            <TextBlock Text="Title:" Width="60" Foreground="#FFE5E7EB" VerticalAlignment="Center"/>
-            <TextBox x:Name="TitleBox" Width="220"/>
+    <Grid Margin="20">
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="*"/>
+            <ColumnDefinition Width="220"/>
+        </Grid.ColumnDefinitions>
+
+        <StackPanel Grid.Column="0" Margin="0,0,20,0">
+            <StackPanel Orientation="Horizontal" Margin="0,0,0,10">
+                <TextBlock Text="Title:" Width="60" Foreground="#FFE5E7EB" VerticalAlignment="Center"/>
+                <TextBox x:Name="TitleBox" Width="360"/>
+            </StackPanel>
+            <StackPanel Orientation="Horizontal" Margin="0,0,0,10">
+                <TextBlock Text="Author:" Width="60" Foreground="#FFE5E7EB" VerticalAlignment="Center"/>
+                <TextBox x:Name="AuthorBox" Width="360"/>
+            </StackPanel>
+            <StackPanel Orientation="Horizontal" Margin="0,0,0,10">
+                <TextBlock Text="Genre:" Width="60" Foreground="#FFE5E7EB" VerticalAlignment="Center"/>
+                <ComboBox x:Name="GenreBox" Width="360"/>
+            </StackPanel>
+            <StackPanel Orientation="Horizontal" Margin="0,0,0,20">
+                <TextBlock Text="Save to:" Width="60" Foreground="#FFE5E7EB" VerticalAlignment="Center"/>
+                <TextBox x:Name="LocationBox" Width="360" IsReadOnly="True"/>
+                <Button Content="Choose Folder..." Width="120" Margin="4,0,0,0" Click="ChooseFolder_Click"/>
+            </StackPanel>
+            <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,20,0,0">
+                <Button Width="110" Margin="0,0,8,0" Content="Load Project" Click="LoadProject_Click"/>
+                <Button Width="75" Margin="0,0,8,0" Content="OK" Click="Ok_Click"/>
+                <Button Width="75" Content="Cancel" Click="Cancel_Click"/>
+            </StackPanel>
         </StackPanel>
-        <StackPanel Orientation="Horizontal" Margin="0,0,0,10">
-            <TextBlock Text="Author:" Width="60" Foreground="#FFE5E7EB" VerticalAlignment="Center"/>
-            <TextBox x:Name="AuthorBox" Width="220"/>
-        </StackPanel>
-        <StackPanel Orientation="Horizontal" Margin="0,0,0,10">
-            <TextBlock Text="Genre:" Width="60" Foreground="#FFE5E7EB" VerticalAlignment="Center"/>
-            <ComboBox x:Name="GenreBox" Width="220"/>
-        </StackPanel>
-        <StackPanel Orientation="Horizontal" Margin="0,0,0,20">
-            <TextBlock Text="Save to:" Width="60" Foreground="#FFE5E7EB" VerticalAlignment="Center"/>
-            <TextBox x:Name="LocationBox" Width="140" IsReadOnly="True"/>
-            <Button Content="Choose Folder..." Width="100" Margin="4,0,0,0" Click="ChooseFolder_Click"/>
-        </StackPanel>
-        <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
-            <Button Width="75" Margin="0,0,8,0" Content="OK" Click="Ok_Click"/>
-            <Button Width="75" Content="Cancel" Click="Cancel_Click"/>
-        </StackPanel>
-    </StackPanel>
+
+        <Border Grid.Column="1" Width="200" Height="300" Background="#FF232529" BorderBrush="#FF3B3F45" BorderThickness="1" CornerRadius="4" HorizontalAlignment="Center" VerticalAlignment="Center">
+            <TextBlock Text="Support Indie Authors" Foreground="#FFE5E7EB" HorizontalAlignment="Center" VerticalAlignment="Center" TextWrapping="Wrap" TextAlignment="Center"/>
+        </Border>
+    </Grid>
 </Window>

--- a/WordForge/NewProjectWindow.xaml.cs
+++ b/WordForge/NewProjectWindow.xaml.cs
@@ -12,6 +12,7 @@ public partial class NewProjectWindow : Window
     public string ProjectLocation => string.IsNullOrWhiteSpace(LocationBox.Text)
         ? Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments)
         : LocationBox.Text;
+    public bool IsLoad { get; private set; }
 
     public NewProjectWindow()
     {
@@ -28,12 +29,13 @@ public partial class NewProjectWindow : Window
             MessageBox.Show(this, "Title is required.", "Validation", MessageBoxButton.OK, MessageBoxImage.Warning);
             return;
         }
+        IsLoad = false;
         DialogResult = true;
     }
 
     private void Cancel_Click(object sender, RoutedEventArgs e)
     {
-        DialogResult = false;
+        Application.Current.Shutdown();
     }
 
     private void ChooseFolder_Click(object sender, RoutedEventArgs e)
@@ -42,6 +44,16 @@ public partial class NewProjectWindow : Window
         if (dialog.ShowDialog() == WinForms.DialogResult.OK)
         {
             LocationBox.Text = dialog.SelectedPath;
+        }
+    }
+
+    private void LoadProject_Click(object sender, RoutedEventArgs e)
+    {
+        ProjectService.Load();
+        if (ProjectService.CurrentPath != null)
+        {
+            IsLoad = true;
+            DialogResult = true;
         }
     }
 }

--- a/WordForge/ProjectService.cs
+++ b/WordForge/ProjectService.cs
@@ -59,6 +59,7 @@ public static class ProjectService
         var path = Path.Combine(directory, fileName);
         project.CreatedUtc = project.ModifiedUtc = DateTime.UtcNow;
         SaveProject(project, path);
+        InitializeUI();
     }
 
     public static void Save()
@@ -135,6 +136,7 @@ public static class ProjectService
                         {
                             SetCurrent(proj, path);
                             CurrentProject.IsDirty = true;
+                            InitializeUI();
                             return;
                         }
                     }
@@ -150,6 +152,7 @@ public static class ProjectService
                 if (project != null)
                 {
                     SetCurrent(project, path);
+                    InitializeUI();
                 }
             }
             catch (Exception ex)
@@ -373,6 +376,19 @@ public static class ProjectService
         SaveToPath(project, path);
         SetCurrent(project, path);
         AutosaveService.OnManualSave();
+    }
+
+    public static void InitializeUI()
+    {
+        if (Application.Current.MainWindow is not MainWindow main)
+            return;
+
+        main.Title = $"WordForge - {CurrentProject.Title}";
+        main.TopMenuContent.Content = new Menus.TopMenu.TranscriptMenu();
+        var view = new Views.TranscriptView();
+        main.CenterContentElement.Content = view;
+        RightPaneService.Show(RightPaneService.CurrentPane);
+        view.InitializeSelection();
     }
 
     internal static string GetAutosavePath(string path)

--- a/WordForge/RightPaneService.cs
+++ b/WordForge/RightPaneService.cs
@@ -12,7 +12,8 @@ public enum RightPaneKind
     Outline,
     Character,
     Location,
-    Item
+    Item,
+    Lore
 }
 
 public static class RightPaneService
@@ -37,6 +38,7 @@ public static class RightPaneService
                     RightPaneKind.Character => new CharacterBiblePane(),
                     RightPaneKind.Location => new LocationBiblePane(),
                     RightPaneKind.Item => new ItemBiblePane(),
+                    RightPaneKind.Lore => new LoreBiblePane(),
                     _ => new TimelinePane()
                 };
             }

--- a/WordForge/menus/FileMenu.xaml
+++ b/WordForge/menus/FileMenu.xaml
@@ -10,6 +10,7 @@
             <Button Content="Properties" Margin="0,0,0,4" Background="#FFE5E7EB" BorderBrush="#FF9CA3AF" Foreground="#FF111111" Click="Properties_Click"/>
             <Button Content="Print" Margin="0,0,0,4" Background="#FFE5E7EB" BorderBrush="#FF9CA3AF" Foreground="#FF111111" />
             <!-- TODO: Wire up Print -->
+            <Button Content="About" Margin="0,0,0,4" Background="#FFE5E7EB" BorderBrush="#FF9CA3AF" Foreground="#FF111111" />
             <Button Content="Exit" Background="#FFE5E7EB" BorderBrush="#FF9CA3AF" Foreground="#FF111111" Click="Exit_Click" />
         </StackPanel>
     </Border>

--- a/WordForge/menus/FileMenu.xaml.cs
+++ b/WordForge/menus/FileMenu.xaml.cs
@@ -16,13 +16,16 @@ public partial class FileMenu : UserControl
         var window = new NewProjectWindow { Owner = Application.Current.MainWindow };
         if (window.ShowDialog() == true)
         {
-            var project = new Project
+            if (!window.IsLoad)
             {
-                Title = window.ProjectTitle,
-                Author = window.ProjectAuthor,
-                Genre = window.ProjectGenre
-            };
-            ProjectService.CreateNew(project, window.ProjectLocation);
+                var project = new Project
+                {
+                    Title = window.ProjectTitle,
+                    Author = window.ProjectAuthor,
+                    Genre = window.ProjectGenre
+                };
+                ProjectService.CreateNew(project, window.ProjectLocation);
+            }
         }
     }
 

--- a/WordForge/menus/LeftMenu.xaml
+++ b/WordForge/menus/LeftMenu.xaml
@@ -39,6 +39,12 @@
                     <TextBlock Text="ITEM BIBLE" FontWeight="Bold" FontSize="10" HorizontalAlignment="Center"/>
                 </StackPanel>
             </Button>
+            <Button x:Name="LoreBibleButton" Width="96" Height="56" Background="#FF2A2D31" BorderBrush="#FF3B3F45" Foreground="#FFE5E7EB" Cursor="Hand" Click="LoreBibleButton_Click">
+                <StackPanel>
+                    <Rectangle Height="20" Width="20" Fill="#FFBFC5CD" HorizontalAlignment="Center" Margin="0,4,0,2"/>
+                    <TextBlock Text="LORE BIBLE" FontWeight="Bold" FontSize="10" HorizontalAlignment="Center"/>
+                </StackPanel>
+            </Button>
         </StackPanel>
     </Border>
 </UserControl>

--- a/WordForge/menus/LeftMenu.xaml.cs
+++ b/WordForge/menus/LeftMenu.xaml.cs
@@ -67,4 +67,12 @@ public partial class LeftMenu : UserControl
         main.CenterContentElement.Content = new ItemBibleView();
         AnimateMenus();
     }
+
+    private void LoreBibleButton_Click(object sender, RoutedEventArgs e)
+    {
+        var main = (MainWindow)Application.Current.MainWindow;
+        main.TopMenuContent.Content = new LoreBibleMenu();
+        main.CenterContentElement.Content = new LoreBibleView();
+        AnimateMenus();
+    }
 }

--- a/WordForge/menus/topmenu/CharacterBibleMenu.xaml.cs
+++ b/WordForge/menus/topmenu/CharacterBibleMenu.xaml.cs
@@ -14,6 +14,8 @@ public partial class CharacterBibleMenu : UserControl
         RightPaneService.BindButton(OutlineButton, RightPaneKind.Outline);
         RightPaneService.BindButton(LocationButton, RightPaneKind.Location);
         RightPaneService.BindButton(ItemButton, RightPaneKind.Item);
+        RightPaneService.BindButton(LoreButton, RightPaneKind.Lore);
+        CustomizeButton.Click += (_, __) => new CustomizeWindow { Owner = Application.Current.MainWindow }.ShowDialog();
     }
 
     private void HamburgerButton_Click(object sender, RoutedEventArgs e)

--- a/WordForge/menus/topmenu/ItemBibleMenu.xaml
+++ b/WordForge/menus/topmenu/ItemBibleMenu.xaml
@@ -20,6 +20,7 @@
                 <ColumnDefinition Width="330"/>
                 <!-- Bibles group -->
                 <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="120"/>
             </Grid.ColumnDefinitions>
 
             <!-- Hamburger -->
@@ -57,12 +58,19 @@
                         <Button x:Name="CharacterButton" Width="90" Height="36" Margin="0,0,8,0"
                                 Background="#FFE5E7EB" BorderBrush="#FF9CA3AF"
                                 Foreground="#FF111111" FontWeight="SemiBold" Content="Character"/>
-                        <Button x:Name="LocationButton" Width="90" Height="36"
+                        <Button x:Name="LocationButton" Width="90" Height="36" Margin="0,0,8,0"
                                 Background="#FFE5E7EB" BorderBrush="#FF9CA3AF"
                                 Foreground="#FF111111" FontWeight="SemiBold" Content="Location"/>
+                        <Button x:Name="LoreButton" Width="90" Height="36"
+                                Background="#FFE5E7EB" BorderBrush="#FF9CA3AF"
+                                Foreground="#FF111111" FontWeight="SemiBold" Content="Lore"/>
                     </StackPanel>
                 </Grid>
             </Border>
+
+            <!-- Customize button -->
+            <Button x:Name="CustomizeButton" Grid.Column="10" Height="52" Width="120" Background="#FFE5E7EB" BorderBrush="#FF9CA3AF"
+                    Foreground="#FF111111" FontWeight="Bold" Content="Customize" HorizontalAlignment="Right"/>
         </Grid>
     </Border>
 </UserControl>

--- a/WordForge/menus/topmenu/ItemBibleMenu.xaml.cs
+++ b/WordForge/menus/topmenu/ItemBibleMenu.xaml.cs
@@ -14,6 +14,8 @@ public partial class ItemBibleMenu : UserControl
         RightPaneService.BindButton(OutlineButton, RightPaneKind.Outline);
         RightPaneService.BindButton(CharacterButton, RightPaneKind.Character);
         RightPaneService.BindButton(LocationButton, RightPaneKind.Location);
+        RightPaneService.BindButton(LoreButton, RightPaneKind.Lore);
+        CustomizeButton.Click += (_, __) => new CustomizeWindow { Owner = Application.Current.MainWindow }.ShowDialog();
     }
 
     private void HamburgerButton_Click(object sender, RoutedEventArgs e)

--- a/WordForge/menus/topmenu/LocationBibleMenu.xaml
+++ b/WordForge/menus/topmenu/LocationBibleMenu.xaml
@@ -20,6 +20,7 @@
                 <ColumnDefinition Width="330"/>
                 <!-- Bibles group -->
                 <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="120"/>
             </Grid.ColumnDefinitions>
 
             <!-- Hamburger -->
@@ -57,12 +58,19 @@
                         <Button x:Name="CharacterButton" Width="90" Height="36" Margin="0,0,8,0"
                                 Background="#FFE5E7EB" BorderBrush="#FF9CA3AF"
                                 Foreground="#FF111111" FontWeight="SemiBold" Content="Character"/>
-                        <Button x:Name="ItemButton" Width="90" Height="36"
+                        <Button x:Name="ItemButton" Width="90" Height="36" Margin="0,0,8,0"
                                 Background="#FFE5E7EB" BorderBrush="#FF9CA3AF"
                                 Foreground="#FF111111" FontWeight="SemiBold" Content="Item"/>
+                        <Button x:Name="LoreButton" Width="90" Height="36"
+                                Background="#FFE5E7EB" BorderBrush="#FF9CA3AF"
+                                Foreground="#FF111111" FontWeight="SemiBold" Content="Lore"/>
                     </StackPanel>
                 </Grid>
             </Border>
+
+            <!-- Customize button -->
+            <Button x:Name="CustomizeButton" Grid.Column="10" Height="52" Width="120" Background="#FFE5E7EB" BorderBrush="#FF9CA3AF"
+                    Foreground="#FF111111" FontWeight="Bold" Content="Customize" HorizontalAlignment="Right"/>
         </Grid>
     </Border>
 </UserControl>

--- a/WordForge/menus/topmenu/LocationBibleMenu.xaml.cs
+++ b/WordForge/menus/topmenu/LocationBibleMenu.xaml.cs
@@ -14,6 +14,8 @@ public partial class LocationBibleMenu : UserControl
         RightPaneService.BindButton(OutlineButton, RightPaneKind.Outline);
         RightPaneService.BindButton(CharacterButton, RightPaneKind.Character);
         RightPaneService.BindButton(ItemButton, RightPaneKind.Item);
+        RightPaneService.BindButton(LoreButton, RightPaneKind.Lore);
+        CustomizeButton.Click += (_, __) => new CustomizeWindow { Owner = Application.Current.MainWindow }.ShowDialog();
     }
 
     private void HamburgerButton_Click(object sender, RoutedEventArgs e)

--- a/WordForge/menus/topmenu/LoreBibleMenu.xaml
+++ b/WordForge/menus/topmenu/LoreBibleMenu.xaml
@@ -1,4 +1,4 @@
-<UserControl x:Class="WordForge.Menus.TopMenu.CharacterBibleMenu"
+<UserControl x:Class="WordForge.Menus.TopMenu.LoreBibleMenu"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:menus="clr-namespace:WordForge.Menus">
@@ -6,19 +6,14 @@
         <Grid Margin="12,12,12,10">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="40"/>
-                <!-- Hamburger -->
                 <ColumnDefinition Width="16"/>
                 <ColumnDefinition Width="140"/>
-                <!-- Title 'Right Pane' -->
                 <ColumnDefinition Width="16"/>
                 <ColumnDefinition Width="120"/>
-                <!-- Timeline -->
                 <ColumnDefinition Width="12"/>
                 <ColumnDefinition Width="120"/>
-                <!-- Outline -->
                 <ColumnDefinition Width="18"/>
                 <ColumnDefinition Width="330"/>
-                <!-- Bibles group -->
                 <ColumnDefinition Width="*"/>
                 <ColumnDefinition Width="120"/>
             </Grid.ColumnDefinitions>
@@ -55,15 +50,15 @@
                     </Grid.RowDefinitions>
                     <TextBlock Text="Bibles" Foreground="#FFE5E7EB" FontWeight="Bold" HorizontalAlignment="Center"/>
                     <StackPanel Grid.Row="2" Orientation="Horizontal" HorizontalAlignment="Center">
+                        <Button x:Name="CharacterButton" Width="90" Height="36" Margin="0,0,8,0"
+                                Background="#FFE5E7EB" BorderBrush="#FF9CA3AF"
+                                Foreground="#FF111111" FontWeight="SemiBold" Content="Character"/>
                         <Button x:Name="LocationButton" Width="90" Height="36" Margin="0,0,8,0"
                                 Background="#FFE5E7EB" BorderBrush="#FF9CA3AF"
                                 Foreground="#FF111111" FontWeight="SemiBold" Content="Location"/>
-                        <Button x:Name="ItemButton" Width="90" Height="36" Margin="0,0,8,0"
+                        <Button x:Name="ItemButton" Width="90" Height="36"
                                 Background="#FFE5E7EB" BorderBrush="#FF9CA3AF"
                                 Foreground="#FF111111" FontWeight="SemiBold" Content="Item"/>
-                        <Button x:Name="LoreButton" Width="90" Height="36"
-                                Background="#FFE5E7EB" BorderBrush="#FF9CA3AF"
-                                Foreground="#FF111111" FontWeight="SemiBold" Content="Lore"/>
                     </StackPanel>
                 </Grid>
             </Border>

--- a/WordForge/menus/topmenu/LoreBibleMenu.xaml.cs
+++ b/WordForge/menus/topmenu/LoreBibleMenu.xaml.cs
@@ -4,9 +4,9 @@ using WordForge;
 
 namespace WordForge.Menus.TopMenu;
 
-public partial class TranscriptMenu : UserControl
+public partial class LoreBibleMenu : UserControl
 {
-    public TranscriptMenu()
+    public LoreBibleMenu()
     {
         InitializeComponent();
         HamburgerButton.Click += HamburgerButton_Click;
@@ -15,7 +15,6 @@ public partial class TranscriptMenu : UserControl
         RightPaneService.BindButton(CharacterButton, RightPaneKind.Character);
         RightPaneService.BindButton(LocationButton, RightPaneKind.Location);
         RightPaneService.BindButton(ItemButton, RightPaneKind.Item);
-        RightPaneService.BindButton(LoreButton, RightPaneKind.Lore);
         CustomizeButton.Click += (_, __) => new CustomizeWindow { Owner = Application.Current.MainWindow }.ShowDialog();
     }
 

--- a/WordForge/menus/topmenu/OutlineMenu.xaml
+++ b/WordForge/menus/topmenu/OutlineMenu.xaml
@@ -17,6 +17,7 @@
                 <ColumnDefinition Width="330"/>
                 <!-- Bibles group -->
                 <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="120"/>
             </Grid.ColumnDefinitions>
 
             <!-- Hamburger -->
@@ -53,12 +54,19 @@
                         <Button x:Name="LocationButton" Width="90" Height="36" Margin="0,0,8,0"
                                 Background="#FFE5E7EB" BorderBrush="#FF9CA3AF"
                                 Foreground="#FF111111" FontWeight="SemiBold" Content="Location"/>
-                        <Button x:Name="ItemButton" Width="90" Height="36"
+                        <Button x:Name="ItemButton" Width="90" Height="36" Margin="0,0,8,0"
                                 Background="#FFE5E7EB" BorderBrush="#FF9CA3AF"
                                 Foreground="#FF111111" FontWeight="SemiBold" Content="Item"/>
+                        <Button x:Name="LoreButton" Width="90" Height="36"
+                                Background="#FFE5E7EB" BorderBrush="#FF9CA3AF"
+                                Foreground="#FF111111" FontWeight="SemiBold" Content="Lore"/>
                     </StackPanel>
                 </Grid>
             </Border>
+
+            <!-- Customize button -->
+            <Button x:Name="CustomizeButton" Grid.Column="8" Height="52" Width="120" Background="#FFE5E7EB" BorderBrush="#FF9CA3AF"
+                    Foreground="#FF111111" FontWeight="Bold" Content="Customize" HorizontalAlignment="Right"/>
         </Grid>
     </Border>
 </UserControl>

--- a/WordForge/menus/topmenu/OutlineMenu.xaml.cs
+++ b/WordForge/menus/topmenu/OutlineMenu.xaml.cs
@@ -14,6 +14,8 @@ public partial class OutlineMenu : UserControl
         RightPaneService.BindButton(CharacterButton, RightPaneKind.Character);
         RightPaneService.BindButton(LocationButton, RightPaneKind.Location);
         RightPaneService.BindButton(ItemButton, RightPaneKind.Item);
+        RightPaneService.BindButton(LoreButton, RightPaneKind.Lore);
+        CustomizeButton.Click += (_, __) => new CustomizeWindow { Owner = Application.Current.MainWindow }.ShowDialog();
     }
 
     private void HamburgerButton_Click(object sender, RoutedEventArgs e)

--- a/WordForge/menus/topmenu/TimelineMenu.xaml
+++ b/WordForge/menus/topmenu/TimelineMenu.xaml
@@ -17,6 +17,7 @@
                 <ColumnDefinition Width="330"/>
                 <!-- Bibles group -->
                 <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="120"/>
             </Grid.ColumnDefinitions>
 
             <!-- Hamburger -->
@@ -53,12 +54,19 @@
                         <Button x:Name="LocationButton" Width="90" Height="36" Margin="0,0,8,0"
                                 Background="#FFE5E7EB" BorderBrush="#FF9CA3AF"
                                 Foreground="#FF111111" FontWeight="SemiBold" Content="Location"/>
-                        <Button x:Name="ItemButton" Width="90" Height="36"
+                        <Button x:Name="ItemButton" Width="90" Height="36" Margin="0,0,8,0"
                                 Background="#FFE5E7EB" BorderBrush="#FF9CA3AF"
                                 Foreground="#FF111111" FontWeight="SemiBold" Content="Item"/>
+                        <Button x:Name="LoreButton" Width="90" Height="36"
+                                Background="#FFE5E7EB" BorderBrush="#FF9CA3AF"
+                                Foreground="#FF111111" FontWeight="SemiBold" Content="Lore"/>
                     </StackPanel>
                 </Grid>
             </Border>
+
+            <!-- Customize button -->
+            <Button x:Name="CustomizeButton" Grid.Column="10" Height="52" Width="120" Background="#FFE5E7EB" BorderBrush="#FF9CA3AF"
+                    Foreground="#FF111111" FontWeight="Bold" Content="Customize" HorizontalAlignment="Right"/>
         </Grid>
     </Border>
 </UserControl>

--- a/WordForge/menus/topmenu/TimelineMenu.xaml.cs
+++ b/WordForge/menus/topmenu/TimelineMenu.xaml.cs
@@ -14,6 +14,8 @@ public partial class TimelineMenu : UserControl
         RightPaneService.BindButton(CharacterButton, RightPaneKind.Character);
         RightPaneService.BindButton(LocationButton, RightPaneKind.Location);
         RightPaneService.BindButton(ItemButton, RightPaneKind.Item);
+        RightPaneService.BindButton(LoreButton, RightPaneKind.Lore);
+        CustomizeButton.Click += (_, __) => new CustomizeWindow { Owner = Application.Current.MainWindow }.ShowDialog();
     }
 
     private void HamburgerButton_Click(object sender, RoutedEventArgs e)

--- a/WordForge/menus/topmenu/TranscriptMenu.xaml
+++ b/WordForge/menus/topmenu/TranscriptMenu.xaml
@@ -20,6 +20,7 @@
                 <ColumnDefinition Width="330"/>
                 <!-- Bibles group -->
                 <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="120"/>
             </Grid.ColumnDefinitions>
 
             <!-- Hamburger -->
@@ -60,12 +61,19 @@
                         <Button x:Name="LocationButton" Width="90" Height="36" Margin="0,0,8,0"
                                 Background="#FFE5E7EB" BorderBrush="#FF9CA3AF"
                                 Foreground="#FF111111" FontWeight="SemiBold" Content="Location"/>
-                        <Button x:Name="ItemButton" Width="90" Height="36"
+                        <Button x:Name="ItemButton" Width="90" Height="36" Margin="0,0,8,0"
                                 Background="#FFE5E7EB" BorderBrush="#FF9CA3AF"
                                 Foreground="#FF111111" FontWeight="SemiBold" Content="Item"/>
+                        <Button x:Name="LoreButton" Width="90" Height="36"
+                                Background="#FFE5E7EB" BorderBrush="#FF9CA3AF"
+                                Foreground="#FF111111" FontWeight="SemiBold" Content="Lore"/>
                     </StackPanel>
                 </Grid>
             </Border>
+
+            <!-- Customize button -->
+            <Button x:Name="CustomizeButton" Grid.Column="10" Height="52" Width="120" Background="#FFE5E7EB" BorderBrush="#FF9CA3AF"
+                    Foreground="#FF111111" FontWeight="Bold" Content="Customize" HorizontalAlignment="Right"/>
         </Grid>
     </Border>
 </UserControl>

--- a/WordForge/panes/LoreBiblePane.xaml
+++ b/WordForge/panes/LoreBiblePane.xaml
@@ -1,0 +1,8 @@
+<UserControl x:Class="WordForge.Panes.LoreBiblePane"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <Grid>
+        <TextBlock Text="Lore Bible Pane" Foreground="#FFE5E7EB" FontWeight="Bold"
+                   HorizontalAlignment="Center" VerticalAlignment="Center"/>
+    </Grid>
+</UserControl>

--- a/WordForge/panes/LoreBiblePane.xaml.cs
+++ b/WordForge/panes/LoreBiblePane.xaml.cs
@@ -1,0 +1,11 @@
+using System.Windows.Controls;
+
+namespace WordForge.Panes;
+
+public partial class LoreBiblePane : UserControl
+{
+    public LoreBiblePane()
+    {
+        InitializeComponent();
+    }
+}

--- a/WordForge/views/LoreBibleView.xaml
+++ b/WordForge/views/LoreBibleView.xaml
@@ -1,0 +1,14 @@
+<UserControl x:Class="WordForge.Views.LoreBibleView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="28"/>
+            <RowDefinition Height="*"/>
+        </Grid.RowDefinitions>
+
+        <TextBlock Grid.Row="0" Text="LORE BIBLE" Foreground="#FFE5E7EB" FontWeight="Bold" Margin="8,0,0,0"/>
+
+        <Border Grid.Row="1" Background="#FF26282C" BorderBrush="#FF3B3F45" BorderThickness="1" CornerRadius="4"/>
+    </Grid>
+</UserControl>

--- a/WordForge/views/LoreBibleView.xaml.cs
+++ b/WordForge/views/LoreBibleView.xaml.cs
@@ -1,0 +1,11 @@
+using System.Windows.Controls;
+
+namespace WordForge.Views;
+
+public partial class LoreBibleView : UserControl
+{
+    public LoreBibleView()
+    {
+        InitializeComponent();
+    }
+}

--- a/WordForge/views/TranscriptView.xaml.cs
+++ b/WordForge/views/TranscriptView.xaml.cs
@@ -93,6 +93,34 @@ public partial class TranscriptView : UserControl
         }
     }
 
+    public void InitializeSelection()
+    {
+        if (ProjectService.CurrentProject.Chapters.Count == 0)
+        {
+            ClearSelection();
+            Editor.Text = string.Empty;
+            UpdateCounts();
+            return;
+        }
+
+        var firstChapter = ProjectService.CurrentProject.Chapters[0];
+        if (firstChapter.Scenes.Count > 0)
+        {
+            _selectedScene = firstChapter.Scenes[0];
+            _selectedChapter = null;
+            SelectItem(_selectedScene);
+            Editor.Text = _selectedScene.Text;
+        }
+        else
+        {
+            _selectedScene = null;
+            _selectedChapter = firstChapter;
+            SelectItem(firstChapter);
+            Editor.Text = string.Join("\n***\n", firstChapter.Scenes.Select(s => s.Text));
+        }
+        UpdateCounts();
+    }
+
     private void AddChapter_Click(object sender, RoutedEventArgs e)
     {
         var chapter = new Chapter { Title = $"Chapter {ProjectService.CurrentProject.Chapters.Count + 1}" };


### PR DESCRIPTION
## Summary
- Introduce Lore Bible placeholders and controls for center and right panes
- Launch redesigned New Project dialog on startup with load option and ad placeholder
- Add pane customization window and menu entries including new About item

## Testing
- `dotnet build` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68a670de132083309d24332c4ff44774