### PR TITLE
Fix startup flow to keep application open after project selection

### DIFF
--- a/WordForge/App.xaml.cs
+++ b/WordForge/App.xaml.cs
@@ -7,28 +7,49 @@ public partial class App : Application
     protected override void OnStartup(StartupEventArgs e)
     {
         base.OnStartup(e);
+        Current.ShutdownMode = ShutdownMode.OnExplicitShutdown;
 
-        var window = new NewProjectWindow();
-        if (window.ShowDialog() == true)
+        while (true)
         {
-            var main = new MainWindow();
-            MainWindow = main;
-            if (!window.IsLoad)
+            var window = new NewProjectWindow();
+            window.ShowDialog();
+            var result = window.Result;
+
+            if (result.Action == StartupAction.Cancel)
+            {
+                Shutdown();
+                return;
+            }
+
+            if (result.Action == StartupAction.New)
             {
                 var project = new Project
                 {
-                    Title = window.ProjectTitle,
-                    Author = window.ProjectAuthor,
-                    Genre = window.ProjectGenre
+                    Title = result.Title ?? string.Empty,
+                    Author = result.Author ?? string.Empty,
+                    Genre = result.Genre ?? string.Empty
                 };
-                ProjectService.CreateNew(project, window.ProjectLocation);
+                var chapter = new Chapter { Title = "Chapter 1" };
+                chapter.Scenes.Add(new Scene { Title = "Scene 1" });
+                project.Chapters.Add(chapter);
+                ProjectService.StartNew(project, result.FolderPath);
+                break;
             }
-            main.Show();
-            ProjectService.InitializeUI();
+
+            if (result.Action == StartupAction.Load)
+            {
+                if (!string.IsNullOrWhiteSpace(result.LoadPath) && ProjectService.LoadFromFile(result.LoadPath))
+                {
+                    break;
+                }
+                MessageBox.Show("Failed to load project.", "Load", MessageBoxButton.OK, MessageBoxImage.Error);
+            }
         }
-        else
-        {
-            Shutdown();
-        }
+
+        var main = new MainWindow();
+        MainWindow = main;
+        main.Show();
+        Current.ShutdownMode = ShutdownMode.OnMainWindowClose;
+        ProjectService.InitializeUI();
     }
 }

--- a/WordForge/NewProjectWindow.xaml.cs
+++ b/WordForge/NewProjectWindow.xaml.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Windows;
+using Microsoft.Win32;
 using WinForms = System.Windows.Forms;
 
 namespace WordForge;
@@ -12,7 +13,7 @@ public partial class NewProjectWindow : Window
     public string ProjectLocation => string.IsNullOrWhiteSpace(LocationBox.Text)
         ? Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments)
         : LocationBox.Text;
-    public bool IsLoad { get; private set; }
+    public StartupResult Result { get; private set; } = new() { Action = StartupAction.Cancel };
 
     public NewProjectWindow()
     {
@@ -29,13 +30,21 @@ public partial class NewProjectWindow : Window
             MessageBox.Show(this, "Title is required.", "Validation", MessageBoxButton.OK, MessageBoxImage.Warning);
             return;
         }
-        IsLoad = false;
+        Result = new StartupResult
+        {
+            Action = StartupAction.New,
+            Title = ProjectTitle,
+            Author = ProjectAuthor,
+            Genre = ProjectGenre,
+            FolderPath = ProjectLocation
+        };
         DialogResult = true;
     }
 
     private void Cancel_Click(object sender, RoutedEventArgs e)
     {
-        Application.Current.Shutdown();
+        Result = new StartupResult { Action = StartupAction.Cancel };
+        DialogResult = false;
     }
 
     private void ChooseFolder_Click(object sender, RoutedEventArgs e)
@@ -49,10 +58,19 @@ public partial class NewProjectWindow : Window
 
     private void LoadProject_Click(object sender, RoutedEventArgs e)
     {
-        ProjectService.Load();
-        if (ProjectService.CurrentPath != null)
+        var dialog = new OpenFileDialog
         {
-            IsLoad = true;
+            Filter = "WordForge Project (*.forge)|*.forge",
+            DefaultExt = ".forge",
+            InitialDirectory = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments)
+        };
+        if (dialog.ShowDialog() == true)
+        {
+            Result = new StartupResult
+            {
+                Action = StartupAction.Load,
+                LoadPath = dialog.FileName
+            };
             DialogResult = true;
         }
     }

--- a/WordForge/ProjectService.cs
+++ b/WordForge/ProjectService.cs
@@ -49,6 +49,19 @@ public static class ProjectService
 
     public static string? CurrentPath { get; private set; } = null;
 
+    public static void StartNew(Project project, string? directory)
+    {
+        directory = string.IsNullOrWhiteSpace(directory)
+            ? Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments)
+            : directory;
+        Directory.CreateDirectory(directory);
+        var fileName = SanitizeFileName(project.Title) + ".forge";
+        var path = Path.Combine(directory, fileName);
+        project.CreatedUtc = project.ModifiedUtc = DateTime.UtcNow;
+        SetCurrent(project, path);
+        CurrentProject.IsDirty = true;
+    }
+
     public static void CreateNew(Project project, string? directory)
     {
         directory = string.IsNullOrWhiteSpace(directory)
@@ -160,6 +173,24 @@ public static class ProjectService
                 MessageBox.Show(ex.Message, "Load", MessageBoxButton.OK, MessageBoxImage.Error);
             }
         }
+    }
+
+    public static bool LoadFromFile(string path)
+    {
+        try
+        {
+            var project = LoadFromPath(path);
+            if (project != null)
+            {
+                SetCurrent(project, path);
+                return true;
+            }
+        }
+        catch (Exception ex)
+        {
+            MessageBox.Show(ex.Message, "Load", MessageBoxButton.OK, MessageBoxImage.Error);
+        }
+        return false;
     }
 
     internal static void SaveToPath(Project project, string path, bool markClean = true)

--- a/WordForge/StartupResult.cs
+++ b/WordForge/StartupResult.cs
@@ -1,0 +1,18 @@
+namespace WordForge;
+
+public enum StartupAction
+{
+    New,
+    Load,
+    Cancel
+}
+
+public record StartupResult
+{
+    public StartupAction Action { get; init; }
+    public string? Title { get; init; }
+    public string? Author { get; init; }
+    public string? Genre { get; init; }
+    public string? FolderPath { get; init; }
+    public string? LoadPath { get; init; }
+}


### PR DESCRIPTION
## Summary
- Add `StartupResult` to capture new/load/cancel result from the startup dialog
- Refactor `NewProjectWindow` to return a result object instead of shutting down the app
- Rewrite `App.OnStartup` to handle new/load workflows, initialize project services, and manage shutdown modes
- Extend `ProjectService` with `StartNew` and `LoadFromFile` helpers for in-memory creation and file loading

## Testing
- ⚠️ `dotnet build` *(missing `dotnet` runtime)*

------
https://chatgpt.com/codex/tasks/task_e_68a703390f3483309e2bdb8778cdc15d