### PR TITLE
Rebuild Bibles ribbon and add export scope controls

### DIFF
--- a/WordForge/MainWindow.xaml
+++ b/WordForge/MainWindow.xaml
@@ -50,7 +50,7 @@
 
         <!-- ===== BOTTOM AD / INFO BAR ===== -->
         <Border Grid.Row="2" Background="#FF111315" BorderBrush="#FF30D158" BorderThickness="1,1,1,0">
-            <TextBlock Text="Ad/Info Area" Foreground="#FF30D158" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+            <TextBlock x:Name="StatusBarText" Text="Ready" Foreground="#FF30D158" HorizontalAlignment="Center" VerticalAlignment="Center"/>
         </Border>
     </Grid>
 </Window>

--- a/WordForge/MainWindow.xaml.cs
+++ b/WordForge/MainWindow.xaml.cs
@@ -31,6 +31,7 @@ namespace WordForge
             TopMenuContent.Content = new TranscriptMenu();
             CenterContentElement.Content = new TranscriptView();
             RightPaneService.Show(RightPaneKind.Timeline);
+            StatusService.StatusChanged += message => Dispatcher.Invoke(() => StatusBarText.Text = message);
         }
     }
 }

--- a/WordForge/StatusService.cs
+++ b/WordForge/StatusService.cs
@@ -1,0 +1,14 @@
+using System;
+using System.Windows;
+
+namespace WordForge;
+
+public static class StatusService
+{
+    public static event Action<string>? StatusChanged;
+
+    public static void Log(string message)
+    {
+        StatusChanged?.Invoke(message);
+    }
+}

--- a/WordForge/menus/topmenu/CharacterBibleMenu.xaml
+++ b/WordForge/menus/topmenu/CharacterBibleMenu.xaml
@@ -1,7 +1,8 @@
 <UserControl x:Class="WordForge.Menus.TopMenu.CharacterBibleMenu"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:menus="clr-namespace:WordForge.Menus">
+             xmlns:menus="clr-namespace:WordForge.Menus"
+             xmlns:top="clr-namespace:WordForge.Menus.TopMenu">
     <Border Background="#FF2A2D31" BorderBrush="#FF0F1012" BorderThickness="0,0,0,1">
         <Grid Margin="12,12,12,10">
             <Grid.ColumnDefinitions>
@@ -17,8 +18,11 @@
                 <ColumnDefinition Width="120"/>
                 <!-- Outline -->
                 <ColumnDefinition Width="18"/>
-                <ColumnDefinition Width="330"/>
+                <ColumnDefinition Width="Auto" MinWidth="320"/>
                 <!-- Bibles group -->
+                <ColumnDefinition Width="18"/>
+                <ColumnDefinition Width="Auto" MinWidth="400"/>
+                <!-- Export group -->
                 <ColumnDefinition Width="*"/>
                 <ColumnDefinition Width="120"/>
             </Grid.ColumnDefinitions>
@@ -54,7 +58,7 @@
                         <RowDefinition Height="*"/>
                     </Grid.RowDefinitions>
                     <TextBlock Text="Bibles" Foreground="#FFE5E7EB" FontWeight="Bold" HorizontalAlignment="Center"/>
-                    <StackPanel Grid.Row="2" Orientation="Horizontal" HorizontalAlignment="Center">
+                    <UniformGrid Grid.Row="2" Rows="1" Columns="3" HorizontalAlignment="Center">
                         <Button x:Name="LocationButton" Width="90" Height="36" Margin="0,0,8,0"
                                 Background="#FFE5E7EB" BorderBrush="#FF9CA3AF"
                                 Foreground="#FF111111" FontWeight="SemiBold" Content="Location"/>
@@ -64,12 +68,14 @@
                         <Button x:Name="LoreButton" Width="90" Height="36"
                                 Background="#FFE5E7EB" BorderBrush="#FF9CA3AF"
                                 Foreground="#FF111111" FontWeight="SemiBold" Content="Lore"/>
-                    </StackPanel>
+                    </UniformGrid>
                 </Grid>
             </Border>
 
+            <top:ExportGroup Grid.Column="10" />
+
             <!-- Customize button -->
-            <Button x:Name="CustomizeButton" Grid.Column="10" Height="52" Width="120" Background="#FFE5E7EB" BorderBrush="#FF9CA3AF"
+            <Button x:Name="CustomizeButton" Grid.Column="12" Height="52" Width="120" Background="#FFE5E7EB" BorderBrush="#FF9CA3AF"
                     Foreground="#FF111111" FontWeight="Bold" Content="Customize" HorizontalAlignment="Right"/>
         </Grid>
     </Border>

--- a/WordForge/menus/topmenu/ExportGroup.xaml
+++ b/WordForge/menus/topmenu/ExportGroup.xaml
@@ -1,0 +1,20 @@
+<UserControl x:Class="WordForge.Menus.TopMenu.ExportGroup"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <Border Background="#FF232529" BorderBrush="#FF3B3F45" BorderThickness="1" CornerRadius="6" Padding="10">
+        <Grid>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="8"/>
+                <RowDefinition Height="*"/>
+            </Grid.RowDefinitions>
+            <TextBlock Text="Export" Foreground="#FFE5E7EB" FontWeight="Bold" HorizontalAlignment="Center"/>
+            <UniformGrid Grid.Row="2" Rows="1" Columns="4" HorizontalAlignment="Center">
+                <Button x:Name="PdfButton" Width="90" Height="36" Margin="0,0,8,0" Background="#FFE5E7EB" BorderBrush="#FF9CA3AF" Foreground="#FF111111" FontWeight="SemiBold" Content="PDF"/>
+                <Button x:Name="DocxButton" Width="90" Height="36" Margin="0,0,8,0" Background="#FFE5E7EB" BorderBrush="#FF9CA3AF" Foreground="#FF111111" FontWeight="SemiBold" Content="DOCX"/>
+                <Button x:Name="RtfButton" Width="90" Height="36" Margin="0,0,8,0" Background="#FFE5E7EB" BorderBrush="#FF9CA3AF" Foreground="#FF111111" FontWeight="SemiBold" Content="RTF"/>
+                <Button x:Name="TxtButton" Width="90" Height="36" Background="#FFE5E7EB" BorderBrush="#FF9CA3AF" Foreground="#FF111111" FontWeight="SemiBold" Content="TXT"/>
+            </UniformGrid>
+        </Grid>
+    </Border>
+</UserControl>

--- a/WordForge/menus/topmenu/ExportGroup.xaml.cs
+++ b/WordForge/menus/topmenu/ExportGroup.xaml.cs
@@ -1,0 +1,15 @@
+using System.Windows.Controls;
+
+namespace WordForge.Menus.TopMenu;
+
+public partial class ExportGroup : UserControl
+{
+    public ExportGroup()
+    {
+        InitializeComponent();
+        PdfButton.Click += (_, __) => StatusService.Log("Export PDF clicked");
+        DocxButton.Click += (_, __) => StatusService.Log("Export DOCX clicked");
+        RtfButton.Click += (_, __) => StatusService.Log("Export RTF clicked");
+        TxtButton.Click += (_, __) => StatusService.Log("Export TXT clicked");
+    }
+}

--- a/WordForge/menus/topmenu/ItemBibleMenu.xaml
+++ b/WordForge/menus/topmenu/ItemBibleMenu.xaml
@@ -1,7 +1,8 @@
 <UserControl x:Class="WordForge.Menus.TopMenu.ItemBibleMenu"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:menus="clr-namespace:WordForge.Menus">
+             xmlns:menus="clr-namespace:WordForge.Menus"
+             xmlns:top="clr-namespace:WordForge.Menus.TopMenu">
     <Border Background="#FF2A2D31" BorderBrush="#FF0F1012" BorderThickness="0,0,0,1">
         <Grid Margin="12,12,12,10">
             <Grid.ColumnDefinitions>
@@ -17,8 +18,11 @@
                 <ColumnDefinition Width="120"/>
                 <!-- Outline -->
                 <ColumnDefinition Width="18"/>
-                <ColumnDefinition Width="330"/>
+                <ColumnDefinition Width="Auto" MinWidth="320"/>
                 <!-- Bibles group -->
+                <ColumnDefinition Width="18"/>
+                <ColumnDefinition Width="Auto" MinWidth="400"/>
+                <!-- Export group -->
                 <ColumnDefinition Width="*"/>
                 <ColumnDefinition Width="120"/>
             </Grid.ColumnDefinitions>
@@ -54,7 +58,7 @@
                         <RowDefinition Height="*"/>
                     </Grid.RowDefinitions>
                     <TextBlock Text="Bibles" Foreground="#FFE5E7EB" FontWeight="Bold" HorizontalAlignment="Center"/>
-                    <StackPanel Grid.Row="2" Orientation="Horizontal" HorizontalAlignment="Center">
+                    <UniformGrid Grid.Row="2" Rows="1" Columns="3" HorizontalAlignment="Center">
                         <Button x:Name="CharacterButton" Width="90" Height="36" Margin="0,0,8,0"
                                 Background="#FFE5E7EB" BorderBrush="#FF9CA3AF"
                                 Foreground="#FF111111" FontWeight="SemiBold" Content="Character"/>
@@ -64,12 +68,14 @@
                         <Button x:Name="LoreButton" Width="90" Height="36"
                                 Background="#FFE5E7EB" BorderBrush="#FF9CA3AF"
                                 Foreground="#FF111111" FontWeight="SemiBold" Content="Lore"/>
-                    </StackPanel>
+                    </UniformGrid>
                 </Grid>
             </Border>
 
+            <top:ExportGroup Grid.Column="10" />
+
             <!-- Customize button -->
-            <Button x:Name="CustomizeButton" Grid.Column="10" Height="52" Width="120" Background="#FFE5E7EB" BorderBrush="#FF9CA3AF"
+            <Button x:Name="CustomizeButton" Grid.Column="12" Height="52" Width="120" Background="#FFE5E7EB" BorderBrush="#FF9CA3AF"
                     Foreground="#FF111111" FontWeight="Bold" Content="Customize" HorizontalAlignment="Right"/>
         </Grid>
     </Border>

--- a/WordForge/menus/topmenu/LocationBibleMenu.xaml
+++ b/WordForge/menus/topmenu/LocationBibleMenu.xaml
@@ -1,7 +1,8 @@
 <UserControl x:Class="WordForge.Menus.TopMenu.LocationBibleMenu"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:menus="clr-namespace:WordForge.Menus">
+             xmlns:menus="clr-namespace:WordForge.Menus"
+             xmlns:top="clr-namespace:WordForge.Menus.TopMenu">
     <Border Background="#FF2A2D31" BorderBrush="#FF0F1012" BorderThickness="0,0,0,1">
         <Grid Margin="12,12,12,10">
             <Grid.ColumnDefinitions>
@@ -17,8 +18,11 @@
                 <ColumnDefinition Width="120"/>
                 <!-- Outline -->
                 <ColumnDefinition Width="18"/>
-                <ColumnDefinition Width="330"/>
+                <ColumnDefinition Width="Auto" MinWidth="320"/>
                 <!-- Bibles group -->
+                <ColumnDefinition Width="18"/>
+                <ColumnDefinition Width="Auto" MinWidth="400"/>
+                <!-- Export group -->
                 <ColumnDefinition Width="*"/>
                 <ColumnDefinition Width="120"/>
             </Grid.ColumnDefinitions>
@@ -54,7 +58,7 @@
                         <RowDefinition Height="*"/>
                     </Grid.RowDefinitions>
                     <TextBlock Text="Bibles" Foreground="#FFE5E7EB" FontWeight="Bold" HorizontalAlignment="Center"/>
-                    <StackPanel Grid.Row="2" Orientation="Horizontal" HorizontalAlignment="Center">
+                    <UniformGrid Grid.Row="2" Rows="1" Columns="3" HorizontalAlignment="Center">
                         <Button x:Name="CharacterButton" Width="90" Height="36" Margin="0,0,8,0"
                                 Background="#FFE5E7EB" BorderBrush="#FF9CA3AF"
                                 Foreground="#FF111111" FontWeight="SemiBold" Content="Character"/>
@@ -64,12 +68,14 @@
                         <Button x:Name="LoreButton" Width="90" Height="36"
                                 Background="#FFE5E7EB" BorderBrush="#FF9CA3AF"
                                 Foreground="#FF111111" FontWeight="SemiBold" Content="Lore"/>
-                    </StackPanel>
+                    </UniformGrid>
                 </Grid>
             </Border>
 
+            <top:ExportGroup Grid.Column="10" />
+
             <!-- Customize button -->
-            <Button x:Name="CustomizeButton" Grid.Column="10" Height="52" Width="120" Background="#FFE5E7EB" BorderBrush="#FF9CA3AF"
+            <Button x:Name="CustomizeButton" Grid.Column="12" Height="52" Width="120" Background="#FFE5E7EB" BorderBrush="#FF9CA3AF"
                     Foreground="#FF111111" FontWeight="Bold" Content="Customize" HorizontalAlignment="Right"/>
         </Grid>
     </Border>

--- a/WordForge/menus/topmenu/LoreBibleMenu.xaml
+++ b/WordForge/menus/topmenu/LoreBibleMenu.xaml
@@ -1,7 +1,8 @@
 <UserControl x:Class="WordForge.Menus.TopMenu.LoreBibleMenu"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:menus="clr-namespace:WordForge.Menus">
+             xmlns:menus="clr-namespace:WordForge.Menus"
+             xmlns:top="clr-namespace:WordForge.Menus.TopMenu">
     <Border Background="#FF2A2D31" BorderBrush="#FF0F1012" BorderThickness="0,0,0,1">
         <Grid Margin="12,12,12,10">
             <Grid.ColumnDefinitions>
@@ -13,7 +14,11 @@
                 <ColumnDefinition Width="12"/>
                 <ColumnDefinition Width="120"/>
                 <ColumnDefinition Width="18"/>
-                <ColumnDefinition Width="330"/>
+                <ColumnDefinition Width="Auto" MinWidth="320"/>
+                <!-- Bibles group -->
+                <ColumnDefinition Width="18"/>
+                <ColumnDefinition Width="Auto" MinWidth="400"/>
+                <!-- Export group -->
                 <ColumnDefinition Width="*"/>
                 <ColumnDefinition Width="120"/>
             </Grid.ColumnDefinitions>
@@ -49,7 +54,7 @@
                         <RowDefinition Height="*"/>
                     </Grid.RowDefinitions>
                     <TextBlock Text="Bibles" Foreground="#FFE5E7EB" FontWeight="Bold" HorizontalAlignment="Center"/>
-                    <StackPanel Grid.Row="2" Orientation="Horizontal" HorizontalAlignment="Center">
+                    <UniformGrid Grid.Row="2" Rows="1" Columns="3" HorizontalAlignment="Center">
                         <Button x:Name="CharacterButton" Width="90" Height="36" Margin="0,0,8,0"
                                 Background="#FFE5E7EB" BorderBrush="#FF9CA3AF"
                                 Foreground="#FF111111" FontWeight="SemiBold" Content="Character"/>
@@ -59,12 +64,14 @@
                         <Button x:Name="ItemButton" Width="90" Height="36"
                                 Background="#FFE5E7EB" BorderBrush="#FF9CA3AF"
                                 Foreground="#FF111111" FontWeight="SemiBold" Content="Item"/>
-                    </StackPanel>
+                    </UniformGrid>
                 </Grid>
             </Border>
 
+            <top:ExportGroup Grid.Column="10" />
+
             <!-- Customize button -->
-            <Button x:Name="CustomizeButton" Grid.Column="10" Height="52" Width="120" Background="#FFE5E7EB" BorderBrush="#FF9CA3AF"
+            <Button x:Name="CustomizeButton" Grid.Column="12" Height="52" Width="120" Background="#FFE5E7EB" BorderBrush="#FF9CA3AF"
                     Foreground="#FF111111" FontWeight="Bold" Content="Customize" HorizontalAlignment="Right"/>
         </Grid>
     </Border>

--- a/WordForge/menus/topmenu/OutlineMenu.xaml
+++ b/WordForge/menus/topmenu/OutlineMenu.xaml
@@ -1,7 +1,8 @@
 <UserControl x:Class="WordForge.Menus.TopMenu.OutlineMenu"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:menus="clr-namespace:WordForge.Menus">
+             xmlns:menus="clr-namespace:WordForge.Menus"
+             xmlns:top="clr-namespace:WordForge.Menus.TopMenu">
     <Border Background="#FF2A2D31" BorderBrush="#FF0F1012" BorderThickness="0,0,0,1">
         <Grid Margin="12,12,12,10">
             <Grid.ColumnDefinitions>
@@ -14,8 +15,11 @@
                 <ColumnDefinition Width="120"/>
                 <!-- Timeline -->
                 <ColumnDefinition Width="18"/>
-                <ColumnDefinition Width="330"/>
+                <ColumnDefinition Width="Auto" MinWidth="400"/>
                 <!-- Bibles group -->
+                <ColumnDefinition Width="18"/>
+                <ColumnDefinition Width="Auto" MinWidth="400"/>
+                <!-- Export group -->
                 <ColumnDefinition Width="*"/>
                 <ColumnDefinition Width="120"/>
             </Grid.ColumnDefinitions>
@@ -47,7 +51,7 @@
                         <RowDefinition Height="*"/>
                     </Grid.RowDefinitions>
                     <TextBlock Text="Bibles" Foreground="#FFE5E7EB" FontWeight="Bold" HorizontalAlignment="Center"/>
-                    <StackPanel Grid.Row="2" Orientation="Horizontal" HorizontalAlignment="Center">
+                    <UniformGrid Grid.Row="2" Rows="1" Columns="4" HorizontalAlignment="Center">
                         <Button x:Name="CharacterButton" Width="90" Height="36" Margin="0,0,8,0"
                                 Background="#FFE5E7EB" BorderBrush="#FF9CA3AF"
                                 Foreground="#FF111111" FontWeight="SemiBold" Content="Character"/>
@@ -60,12 +64,14 @@
                         <Button x:Name="LoreButton" Width="90" Height="36"
                                 Background="#FFE5E7EB" BorderBrush="#FF9CA3AF"
                                 Foreground="#FF111111" FontWeight="SemiBold" Content="Lore"/>
-                    </StackPanel>
+                    </UniformGrid>
                 </Grid>
             </Border>
 
+            <top:ExportGroup Grid.Column="8" />
+
             <!-- Customize button -->
-            <Button x:Name="CustomizeButton" Grid.Column="8" Height="52" Width="120" Background="#FFE5E7EB" BorderBrush="#FF9CA3AF"
+            <Button x:Name="CustomizeButton" Grid.Column="10" Height="52" Width="120" Background="#FFE5E7EB" BorderBrush="#FF9CA3AF"
                     Foreground="#FF111111" FontWeight="Bold" Content="Customize" HorizontalAlignment="Right"/>
         </Grid>
     </Border>

--- a/WordForge/menus/topmenu/TimelineMenu.xaml
+++ b/WordForge/menus/topmenu/TimelineMenu.xaml
@@ -1,7 +1,8 @@
 <UserControl x:Class="WordForge.Menus.TopMenu.TimelineMenu"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:menus="clr-namespace:WordForge.Menus">
+             xmlns:menus="clr-namespace:WordForge.Menus"
+             xmlns:top="clr-namespace:WordForge.Menus.TopMenu">
     <Border Background="#FF2A2D31" BorderBrush="#FF0F1012" BorderThickness="0,0,0,1">
         <Grid Margin="12,12,12,10">
             <Grid.ColumnDefinitions>
@@ -14,8 +15,11 @@
                 <ColumnDefinition Width="120"/>
                 <!-- Outline -->
                 <ColumnDefinition Width="18"/>
-                <ColumnDefinition Width="330"/>
+                <ColumnDefinition Width="Auto" MinWidth="400"/>
                 <!-- Bibles group -->
+                <ColumnDefinition Width="18"/>
+                <ColumnDefinition Width="Auto" MinWidth="400"/>
+                <!-- Export group -->
                 <ColumnDefinition Width="*"/>
                 <ColumnDefinition Width="120"/>
             </Grid.ColumnDefinitions>
@@ -47,7 +51,7 @@
                         <RowDefinition Height="*"/>
                     </Grid.RowDefinitions>
                     <TextBlock Text="Bibles" Foreground="#FFE5E7EB" FontWeight="Bold" HorizontalAlignment="Center"/>
-                    <StackPanel Grid.Row="2" Orientation="Horizontal" HorizontalAlignment="Center">
+                    <UniformGrid Grid.Row="2" Rows="1" Columns="4" HorizontalAlignment="Center">
                         <Button x:Name="CharacterButton" Width="90" Height="36" Margin="0,0,8,0"
                                 Background="#FFE5E7EB" BorderBrush="#FF9CA3AF"
                                 Foreground="#FF111111" FontWeight="SemiBold" Content="Character"/>
@@ -60,9 +64,11 @@
                         <Button x:Name="LoreButton" Width="90" Height="36"
                                 Background="#FFE5E7EB" BorderBrush="#FF9CA3AF"
                                 Foreground="#FF111111" FontWeight="SemiBold" Content="Lore"/>
-                    </StackPanel>
+                    </UniformGrid>
                 </Grid>
             </Border>
+
+            <top:ExportGroup Grid.Column="8" />
 
             <!-- Customize button -->
             <Button x:Name="CustomizeButton" Grid.Column="10" Height="52" Width="120" Background="#FFE5E7EB" BorderBrush="#FF9CA3AF"

--- a/WordForge/menus/topmenu/TranscriptMenu.xaml
+++ b/WordForge/menus/topmenu/TranscriptMenu.xaml
@@ -1,7 +1,8 @@
 <UserControl x:Class="WordForge.Menus.TopMenu.TranscriptMenu"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:menus="clr-namespace:WordForge.Menus">
+             xmlns:menus="clr-namespace:WordForge.Menus"
+             xmlns:top="clr-namespace:WordForge.Menus.TopMenu">
     <Border Background="#FF2A2D31" BorderBrush="#FF0F1012" BorderThickness="0,0,0,1">
         <Grid Margin="12,12,12,10">
             <Grid.ColumnDefinitions>
@@ -17,8 +18,11 @@
                 <ColumnDefinition Width="120"/>
                 <!-- Outline -->
                 <ColumnDefinition Width="18"/>
-                <ColumnDefinition Width="330"/>
+                <ColumnDefinition Width="Auto" MinWidth="400"/>
                 <!-- Bibles group -->
+                <ColumnDefinition Width="18"/>
+                <ColumnDefinition Width="Auto" MinWidth="400"/>
+                <!-- Export group -->
                 <ColumnDefinition Width="*"/>
                 <ColumnDefinition Width="120"/>
             </Grid.ColumnDefinitions>
@@ -54,7 +58,7 @@
                         <RowDefinition Height="*"/>
                     </Grid.RowDefinitions>
                     <TextBlock Text="Bibles" Foreground="#FFE5E7EB" FontWeight="Bold" HorizontalAlignment="Center"/>
-                    <StackPanel Grid.Row="2" Orientation="Horizontal" HorizontalAlignment="Center">
+                    <UniformGrid Grid.Row="2" Rows="1" Columns="4" HorizontalAlignment="Center">
                         <Button x:Name="CharacterButton" Width="90" Height="36" Margin="0,0,8,0"
                                 Background="#FFE5E7EB" BorderBrush="#FF9CA3AF"
                                 Foreground="#FF111111" FontWeight="SemiBold" Content="Character"/>
@@ -67,12 +71,14 @@
                         <Button x:Name="LoreButton" Width="90" Height="36"
                                 Background="#FFE5E7EB" BorderBrush="#FF9CA3AF"
                                 Foreground="#FF111111" FontWeight="SemiBold" Content="Lore"/>
-                    </StackPanel>
+                    </UniformGrid>
                 </Grid>
             </Border>
 
+            <top:ExportGroup Grid.Column="10" />
+
             <!-- Customize button -->
-            <Button x:Name="CustomizeButton" Grid.Column="10" Height="52" Width="120" Background="#FFE5E7EB" BorderBrush="#FF9CA3AF"
+            <Button x:Name="CustomizeButton" Grid.Column="12" Height="52" Width="120" Background="#FFE5E7EB" BorderBrush="#FF9CA3AF"
                     Foreground="#FF111111" FontWeight="Bold" Content="Customize" HorizontalAlignment="Right"/>
         </Grid>
     </Border>

--- a/WordForge/viewmodels/TranscriptViewModel.cs
+++ b/WordForge/viewmodels/TranscriptViewModel.cs
@@ -1,0 +1,42 @@
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+
+namespace WordForge.ViewModels;
+
+public enum CountScope
+{
+    Scene,
+    Chapter,
+    Project
+}
+
+public class TranscriptViewModel : INotifyPropertyChanged
+{
+    private static CountScope _lastScope = CountScope.Chapter;
+    private static bool _scopeSet = false;
+    private CountScope _countScope = _lastScope;
+
+    public ObservableCollection<Chapter> Chapters => ProjectService.CurrentProject.Chapters;
+
+    public CountScope CountScope
+    {
+        get => _countScope;
+        set
+        {
+            if (_countScope != value)
+            {
+                _countScope = value;
+                _lastScope = value;
+                _scopeSet = true;
+                OnPropertyChanged();
+            }
+        }
+    }
+
+    public static bool ScopePersisted => _scopeSet;
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+    private void OnPropertyChanged([CallerMemberName] string? name = null) =>
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
+}

--- a/WordForge/views/TranscriptView.xaml
+++ b/WordForge/views/TranscriptView.xaml
@@ -1,7 +1,8 @@
 <UserControl x:Class="WordForge.Views.TranscriptView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:local="clr-namespace:WordForge">
+             xmlns:local="clr-namespace:WordForge"
+             xmlns:vm="clr-namespace:WordForge.ViewModels">
     <Grid>
         <Grid.ColumnDefinitions>
             <!-- Column 0 holds the sidebar and collapse ribbon -->
@@ -229,6 +230,11 @@
                          FontSize="14" Padding="10" TextChanged="Editor_TextChanged" PreviewKeyDown="Editor_PreviewKeyDown"/>
             </Border>
             <DockPanel Grid.Row="3" LastChildFill="True" Background="#FF1A1B1E" Margin="2,4,2,0">
+                <ComboBox x:Name="ScopeCombo" DockPanel.Dock="Left" Width="100" Margin="6,0" SelectedValuePath="Tag" SelectedValue="{Binding CountScope, Mode=TwoWay}">
+                    <ComboBoxItem x:Name="SceneScopeItem" Content="Scene" Tag="{x:Static vm:CountScope.Scene}"/>
+                    <ComboBoxItem Content="Chapter" Tag="{x:Static vm:CountScope.Chapter}"/>
+                    <ComboBoxItem Content="Project" Tag="{x:Static vm:CountScope.Project}"/>
+                </ComboBox>
                 <TextBlock x:Name="WordCountText" DockPanel.Dock="Left" Text="Words: 0" Foreground="#FFC9CDD3" Margin="6,0"/>
                 <TextBlock x:Name="CharCountText" DockPanel.Dock="Right" Text="Characters: 0" Foreground="#FFC9CDD3" Margin="6,0"/>
             </DockPanel>

--- a/WordForge/views/TranscriptView.xaml.cs
+++ b/WordForge/views/TranscriptView.xaml.cs
@@ -9,6 +9,7 @@ using System.Windows.Media;
 using System.Windows.Controls.Primitives;
 using System.Windows.Threading;
 using WordForge;
+using WordForge.ViewModels;
 
 namespace WordForge.Views;
 
@@ -17,6 +18,7 @@ public partial class TranscriptView : UserControl
     private Chapter? _selectedChapter;
     private Scene? _selectedScene;
     private static bool _sidebarCollapsed = false;
+    private readonly TranscriptViewModel _viewModel = new();
     private Point _dragStartPoint;
     private DependencyObject? _dragStartSource;
     private object? _draggedData;
@@ -54,7 +56,8 @@ public partial class TranscriptView : UserControl
     public TranscriptView()
     {
         InitializeComponent();
-        DataContext = ProjectService.CurrentProject;
+        DataContext = _viewModel;
+        _viewModel.PropertyChanged += ViewModel_PropertyChanged;
         _sceneCheckTimer.Tick += SceneCheckTimer_Tick;
         ProjectService.BeforeSave += OnBeforeSave;
         Unloaded += TranscriptView_Unloaded;
@@ -67,6 +70,14 @@ public partial class TranscriptView : UserControl
             AddChapterButton.Visibility = Visibility.Collapsed;
             AddChapterBar.Visibility = Visibility.Collapsed;
             CollapseButton.Content = ">";
+        }
+    }
+
+    private void ViewModel_PropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName == nameof(TranscriptViewModel.CountScope))
+        {
+            UpdateCounts();
         }
     }
 
@@ -416,18 +427,72 @@ public partial class TranscriptView : UserControl
 
     private void UpdateCounts()
     {
-        var lines = Editor.Text.Replace("\r", string.Empty).Split('\n');
-        if (_selectedChapter != null)
+        ValidateScope();
+        string text = _viewModel.CountScope switch
         {
-            lines = lines.Where(l => !SceneBreakRegex.IsMatch(l)).ToArray();
-        }
-        var text = string.Join("\n", lines);
+            CountScope.Scene => _selectedScene?.Text ?? string.Empty,
+            CountScope.Chapter => GetChapterText(),
+            CountScope.Project => GetProjectText(),
+            _ => string.Empty
+        };
         var words = string.IsNullOrWhiteSpace(text)
             ? 0
             : text.Split(new[] { ' ', '\n', '\r', '\t' }, StringSplitOptions.RemoveEmptyEntries).Length;
         var chars = text.Replace("\n", string.Empty).Length;
         WordCountText.Text = $"Words: {words}";
         CharCountText.Text = $"Characters: {chars}";
+    }
+
+    private string GetChapterText()
+    {
+        if (_selectedChapter != null)
+        {
+            return string.Join("\n", _selectedChapter.Scenes.Select(s => s.Text));
+        }
+        if (_selectedScene != null)
+        {
+            var ch = ProjectService.CurrentProject.Chapters.FirstOrDefault(c => c.Scenes.Contains(_selectedScene));
+            if (ch != null)
+            {
+                return string.Join("\n", ch.Scenes.Select(s => s.Text));
+            }
+            return _selectedScene.Text;
+        }
+        return string.Empty;
+    }
+
+    private string GetProjectText()
+    {
+        return string.Join("\n", ProjectService.CurrentProject.Chapters.SelectMany(c => c.Scenes).Select(s => s.Text));
+    }
+
+    private void ValidateScope()
+    {
+        SceneScopeItem.Visibility = _selectedScene != null ? Visibility.Visible : Visibility.Collapsed;
+
+        if (!TranscriptViewModel.ScopePersisted)
+        {
+            if (_selectedScene != null)
+                _viewModel.CountScope = CountScope.Scene;
+            else if (_selectedChapter != null)
+                _viewModel.CountScope = CountScope.Chapter;
+            else
+                _viewModel.CountScope = CountScope.Project;
+            return;
+        }
+
+        if (_selectedScene == null && _viewModel.CountScope == CountScope.Scene)
+        {
+            _viewModel.CountScope = _selectedChapter != null ? CountScope.Chapter : CountScope.Project;
+        }
+        if (_selectedScene == null && _selectedChapter == null)
+        {
+            _viewModel.CountScope = CountScope.Project;
+        }
+        if (_selectedChapter == null && _viewModel.CountScope == CountScope.Chapter)
+        {
+            _viewModel.CountScope = CountScope.Project;
+        }
     }
 
     private List<string> GetSegments(string text) => SceneBreakRegex.Split(text).ToList();


### PR DESCRIPTION
## Summary
- increase Bibles ribbon width and use uniform grid to avoid clipping
- add new Export group with placeholder PDF/DOCX/RTF/TXT actions
- add transcript count scope dropdown and session-persisted logic

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-9.0` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68a75a6ef198833084179f917c5848c3