### PR TITLE
feat: restructure desktop layout with new pane controls

### DIFF
--- a/WordForge.Desktop/MainWindow.axaml
+++ b/WordForge.Desktop/MainWindow.axaml
@@ -3,38 +3,147 @@
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:vm="clr-namespace:WordForge.Desktop.ViewModels"
-        xmlns:models="clr-namespace:WordForge.Core.Models;assembly=WordForge.Core"
         mc:Ignorable="d" d:DesignWidth="900" d:DesignHeight="600"
         x:Class="WordForge.Desktop.MainWindow"
         Title="WordForge">
     <Window.DataContext>
         <vm:MainViewModel/>
     </Window.DataContext>
-    <DockPanel>
-        <StackPanel Orientation="Horizontal" DockPanel.Dock="Top" Margin="4">
-            <Button Content="Characters" Command="{Binding ShowCharactersCommand}" Margin="2"/>
-            <Button Content="Locations" Command="{Binding ShowLocationsCommand}" Margin="2"/>
-            <Button Content="Items" Command="{Binding ShowItemsCommand}" Margin="2"/>
-            <Button Content="Timeline" Command="{Binding ShowTimelineCommand}" Margin="2"/>
+    <Grid RowDefinitions="Auto,*,1,Auto">
+        <!-- TopBar -->
+        <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="4">
+            <Button Content="☰" Width="40" Height="40" Margin="2"/>
+            <!-- Primary group -->
+            <StackPanel Margin="8,0" VerticalAlignment="Center">
+                <TextBlock Text="Primary" FontWeight="Bold" HorizontalAlignment="Center"/>
+                <StackPanel Orientation="Horizontal">
+                    <ToggleButton Content="Right Pane" IsChecked="{Binding IsRightPaneVisible}" Command="{Binding ToggleRightPaneCommand}" Margin="2"/>
+                    <Button Content="Timeline" Command="{Binding ShowTimelineCenterCommand}" Margin="2"/>
+                    <Button Content="Outline" Command="{Binding ShowOutlineCenterCommand}" Margin="2"/>
+                </StackPanel>
+            </StackPanel>
+            <!-- Bibles group -->
+            <StackPanel Margin="8,0" VerticalAlignment="Center">
+                <TextBlock Text="Bibles" FontWeight="Bold" HorizontalAlignment="Center"/>
+                <StackPanel Orientation="Horizontal">
+                    <Button Content="Character" Width="90" Command="{Binding ShowCharactersCommand}" Margin="2"/>
+                    <Button Content="Location" Width="90" Command="{Binding ShowLocationsCommand}" Margin="2"/>
+                    <Button Content="Item" Width="90" Command="{Binding ShowItemsCommand}" Margin="2"/>
+                </StackPanel>
+            </StackPanel>
+            <!-- Export group -->
+            <StackPanel Margin="8,0" VerticalAlignment="Center">
+                <TextBlock Text="EXPORT" FontWeight="Bold" HorizontalAlignment="Center"/>
+                <StackPanel Orientation="Horizontal">
+                    <Button Content="PDF" Width="70" Command="{Binding ExportPdfCommand}" Margin="2"/>
+                    <Button Content="DOCX" Width="70" Command="{Binding ExportDocxCommand}" Margin="2"/>
+                    <Button Content="RTF" Width="70" Command="{Binding ExportRtfCommand}" Margin="2"/>
+                    <Button Content="TXT" Width="70" Command="{Binding ExportTxtCommand}" Margin="2"/>
+                </StackPanel>
+            </StackPanel>
         </StackPanel>
-        <StackPanel Orientation="Horizontal" DockPanel.Dock="Bottom" Margin="4">
-            <TextBlock Text="{Binding WordCount, StringFormat='Words: {0}'}" Margin="4,0"/>
-            <TextBlock Text="{Binding CharCount, StringFormat='Chars: {0}'}" Margin="4,0"/>
-            <ComboBox ItemsSource="{Binding Scopes}" SelectedItem="{Binding SelectedScope}" Width="120" Margin="4,0"/>
-        </StackPanel>
-        <Grid ColumnDefinitions="2*,4*,3*">
-            <TreeView ItemsSource="{Binding Project.Chapters}" SelectedItem="{Binding CurrentNode}">
-                <TreeView.DataTemplates>
-                    <TreeDataTemplate DataType="models:Chapter" ItemsSource="{Binding Scenes}">
-                        <TextBlock Text="{Binding Title}"/>
-                    </TreeDataTemplate>
-                    <TreeDataTemplate DataType="models:Scene">
-                        <TextBlock Text="{Binding Title}"/>
-                    </TreeDataTemplate>
-                </TreeView.DataTemplates>
-            </TreeView>
-            <TextBox Grid.Column="1" AcceptsReturn="True" Text="Transcript..."/>
-            <ContentControl Grid.Column="2" Content="{Binding RightPane.CurrentPane}"/>
+
+        <!-- Content area -->
+        <Grid Grid.Row="1" ColumnDefinitions="15*,60*,25*">
+            <!-- LeftNav -->
+            <StackPanel Grid.Column="0" Orientation="Vertical" Margin="4">
+                <Button Content="TRANSCRIPT" Command="{Binding ShowTranscriptCommand}" Width="120" Margin="2">
+                    <Button.Styles>
+                        <Style Selector="Button">
+                            <Style.Triggers>
+                                <DataTrigger Binding="{Binding IsTranscriptActive}" Value="True">
+                                    <Setter Property="Background" Value="#008000"/>
+                                </DataTrigger>
+                            </Style.Triggers>
+                        </Style>
+                    </Button.Styles>
+                </Button>
+                <Button Content="TIMELINE" Command="{Binding ShowTimelineCenterCommand}" Width="120" Margin="2">
+                    <Button.Styles>
+                        <Style Selector="Button">
+                            <Style.Triggers>
+                                <DataTrigger Binding="{Binding IsTimelineActive}" Value="True">
+                                    <Setter Property="Background" Value="#008000"/>
+                                </DataTrigger>
+                            </Style.Triggers>
+                        </Style>
+                    </Button.Styles>
+                </Button>
+                <Button Content="OUTLINE" Command="{Binding ShowOutlineCenterCommand}" Width="120" Margin="2">
+                    <Button.Styles>
+                        <Style Selector="Button">
+                            <Style.Triggers>
+                                <DataTrigger Binding="{Binding IsOutlineActive}" Value="True">
+                                    <Setter Property="Background" Value="#008000"/>
+                                </DataTrigger>
+                            </Style.Triggers>
+                        </Style>
+                    </Button.Styles>
+                </Button>
+                <Button Content="CHAR BIBLE" Command="{Binding ShowCharBibleCenterCommand}" Width="120" Margin="2">
+                    <Button.Styles>
+                        <Style Selector="Button">
+                            <Style.Triggers>
+                                <DataTrigger Binding="{Binding IsCharBibleActive}" Value="True">
+                                    <Setter Property="Background" Value="#008000"/>
+                                </DataTrigger>
+                            </Style.Triggers>
+                        </Style>
+                    </Button.Styles>
+                </Button>
+                <Button Content="LOC BIBLE" Command="{Binding ShowLocBibleCenterCommand}" Width="120" Margin="2">
+                    <Button.Styles>
+                        <Style Selector="Button">
+                            <Style.Triggers>
+                                <DataTrigger Binding="{Binding IsLocBibleActive}" Value="True">
+                                    <Setter Property="Background" Value="#008000"/>
+                                </DataTrigger>
+                            </Style.Triggers>
+                        </Style>
+                    </Button.Styles>
+                </Button>
+                <Button Content="ITEM BIBLE" Command="{Binding ShowItemBibleCenterCommand}" Width="120" Margin="2">
+                    <Button.Styles>
+                        <Style Selector="Button">
+                            <Style.Triggers>
+                                <DataTrigger Binding="{Binding IsItemBibleActive}" Value="True">
+                                    <Setter Property="Background" Value="#008000"/>
+                                </DataTrigger>
+                            </Style.Triggers>
+                        </Style>
+                    </Button.Styles>
+                </Button>
+            </StackPanel>
+
+            <!-- Center pane -->
+            <Grid Grid.Column="1" Margin="4">
+                <Grid IsVisible="{Binding IsTranscriptActive}">
+                    <DockPanel Margin="0,0,0,4">
+                        <TextBlock Text="TRANSCRIPT" FontWeight="Bold" DockPanel.Dock="Left"/>
+                        <Button Content="Insert Scene Break" Command="{Binding InsertSceneBreakCommand}" DockPanel.Dock="Right"/>
+                    </DockPanel>
+                    <TextBox AcceptsReturn="True" TextWrapping="Wrap" VerticalScrollBarVisibility="Auto" Text="{Binding TranscriptText}"/>
+                </Grid>
+                <TextBlock IsVisible="{Binding IsTimelineActive}" Text="Timeline Pane" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                <TextBlock IsVisible="{Binding IsOutlineActive}" Text="Outline Pane" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                <TextBlock IsVisible="{Binding IsCharBibleActive}" Text="Character Bible" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                <TextBlock IsVisible="{Binding IsLocBibleActive}" Text="Location Bible" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                <TextBlock IsVisible="{Binding IsItemBibleActive}" Text="Item Bible" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+            </Grid>
+
+            <!-- Right pane -->
+            <ContentControl Grid.Column="2" Content="{Binding RightPane.CurrentPane}" IsVisible="{Binding IsRightPaneVisible}" Margin="4"/>
         </Grid>
-    </DockPanel>
+
+        <!-- Divider -->
+        <Border Grid.Row="2" Height="1" Background="Gray"/>
+
+        <!-- StatusBar -->
+        <Grid Grid.Row="3" ColumnDefinitions="Auto,Auto,*,Auto" Margin="4">
+            <TextBlock Grid.Column="0" Text="{Binding WordCount, StringFormat='Words: {0}'}" Margin="4,0"/>
+            <TextBlock Grid.Column="1" Text="{Binding CharCount, StringFormat='Chars: {0}'}" Margin="4,0"/>
+            <ComboBox Grid.Column="2" ItemsSource="{Binding Scopes}" SelectedItem="{Binding SelectedScope}" Width="120" Margin="4,0" IsVisible="{Binding IsTranscriptActive}"/>
+            <TextBlock Grid.Column="3" Text="{Binding StatusMessage}" HorizontalAlignment="Right" Margin="4,0"/>
+        </Grid>
+    </Grid>
 </Window>

--- a/WordForge.Desktop/ViewModels/ActiveCenterPane.cs
+++ b/WordForge.Desktop/ViewModels/ActiveCenterPane.cs
@@ -1,0 +1,11 @@
+namespace WordForge.Desktop.ViewModels;
+
+public enum ActiveCenterPane
+{
+    Transcript,
+    Timeline,
+    Outline,
+    CharBible,
+    LocBible,
+    ItemBible
+}

--- a/WordForge.Desktop/ViewModels/ActiveRightPane.cs
+++ b/WordForge.Desktop/ViewModels/ActiveRightPane.cs
@@ -1,0 +1,8 @@
+namespace WordForge.Desktop.ViewModels;
+
+public enum ActiveRightPane
+{
+    Character,
+    Location,
+    Item
+}

--- a/WordForge.Desktop/ViewModels/MainViewModel.cs
+++ b/WordForge.Desktop/ViewModels/MainViewModel.cs
@@ -1,4 +1,6 @@
+using System;
 using System.Collections.ObjectModel;
+using System.Linq;
 using System.Windows.Input;
 using WordForge.Core.Models;
 
@@ -7,6 +9,7 @@ namespace WordForge.Desktop.ViewModels;
 public class MainViewModel : ViewModelBase
 {
     public Project Project { get; } = new();
+
     private object? _currentNode;
     public object? CurrentNode
     {
@@ -16,10 +19,27 @@ public class MainViewModel : ViewModelBase
 
     public RightPaneViewModel RightPane { get; } = new();
 
-    public ICommand ShowCharactersCommand { get; }
-    public ICommand ShowLocationsCommand { get; }
-    public ICommand ShowItemsCommand { get; }
-    public ICommand ShowTimelineCommand { get; }
+    public ObservableCollection<string> Scopes { get; } = new(new[] {"Scene", "Chapter", "Project"});
+
+    private string _selectedScope = "Scene";
+    public string SelectedScope
+    {
+        get => _selectedScope;
+        set => SetProperty(ref _selectedScope, value);
+    }
+
+    private string _transcriptText = string.Empty;
+    public string TranscriptText
+    {
+        get => _transcriptText;
+        set
+        {
+            if (SetProperty(ref _transcriptText, value))
+            {
+                UpdateCounts();
+            }
+        }
+    }
 
     private int _wordCount;
     public int WordCount
@@ -35,14 +55,71 @@ public class MainViewModel : ViewModelBase
         set => SetProperty(ref _charCount, value);
     }
 
-    public ObservableCollection<string> Scopes { get; } = new(new[] {"Scene", "Chapter", "Project"});
-
-    private string _selectedScope = "Scene";
-    public string SelectedScope
+    private ActiveCenterPane _activeCenterPane = ActiveCenterPane.Transcript;
+    public ActiveCenterPane ActiveCenterPane
     {
-        get => _selectedScope;
-        set => SetProperty(ref _selectedScope, value);
+        get => _activeCenterPane;
+        set
+        {
+            if (SetProperty(ref _activeCenterPane, value))
+            {
+                OnPropertyChanged(nameof(IsTranscriptActive));
+                OnPropertyChanged(nameof(IsTimelineActive));
+                OnPropertyChanged(nameof(IsOutlineActive));
+                OnPropertyChanged(nameof(IsCharBibleActive));
+                OnPropertyChanged(nameof(IsLocBibleActive));
+                OnPropertyChanged(nameof(IsItemBibleActive));
+            }
+        }
     }
+
+    public bool IsTranscriptActive => ActiveCenterPane == ActiveCenterPane.Transcript;
+    public bool IsTimelineActive => ActiveCenterPane == ActiveCenterPane.Timeline;
+    public bool IsOutlineActive => ActiveCenterPane == ActiveCenterPane.Outline;
+    public bool IsCharBibleActive => ActiveCenterPane == ActiveCenterPane.CharBible;
+    public bool IsLocBibleActive => ActiveCenterPane == ActiveCenterPane.LocBible;
+    public bool IsItemBibleActive => ActiveCenterPane == ActiveCenterPane.ItemBible;
+
+    private ActiveRightPane _activeRightPane = ActiveRightPane.Character;
+    public ActiveRightPane ActiveRightPane
+    {
+        get => _activeRightPane;
+        set => SetProperty(ref _activeRightPane, value);
+    }
+
+    private bool _isRightPaneVisible = true;
+    public bool IsRightPaneVisible
+    {
+        get => _isRightPaneVisible;
+        set => SetProperty(ref _isRightPaneVisible, value);
+    }
+
+    private string _statusMessage = string.Empty;
+    public string StatusMessage
+    {
+        get => _statusMessage;
+        set => SetProperty(ref _statusMessage, value);
+    }
+
+    public ICommand ShowTranscriptCommand { get; }
+    public ICommand ShowTimelineCenterCommand { get; }
+    public ICommand ShowOutlineCenterCommand { get; }
+    public ICommand ShowCharBibleCenterCommand { get; }
+    public ICommand ShowLocBibleCenterCommand { get; }
+    public ICommand ShowItemBibleCenterCommand { get; }
+
+    public ICommand ToggleRightPaneCommand { get; }
+    public ICommand ShowCharactersCommand { get; }
+    public ICommand ShowLocationsCommand { get; }
+    public ICommand ShowItemsCommand { get; }
+    public ICommand ShowTimelineCommand { get; }
+
+    public ICommand InsertSceneBreakCommand { get; }
+
+    public ICommand ExportPdfCommand { get; }
+    public ICommand ExportDocxCommand { get; }
+    public ICommand ExportRtfCommand { get; }
+    public ICommand ExportTxtCommand { get; }
 
     public MainViewModel()
     {
@@ -55,11 +132,39 @@ public class MainViewModel : ViewModelBase
         Project.Chapters.Add(ch1);
         Project.Chapters.Add(ch2);
 
-        RightPane.CurrentPane = new CharacterPaneViewModel();
+        RightPane.CurrentPane = new TimelinePaneViewModel();
 
-        ShowCharactersCommand = new RelayCommand(_ => RightPane.CurrentPane = new CharacterPaneViewModel());
-        ShowLocationsCommand = new RelayCommand(_ => RightPane.CurrentPane = new LocationPaneViewModel());
-        ShowItemsCommand = new RelayCommand(_ => RightPane.CurrentPane = new ItemPaneViewModel());
-        ShowTimelineCommand = new RelayCommand(_ => RightPane.CurrentPane = new TimelinePaneViewModel());
+        ShowTranscriptCommand = new RelayCommand(_ => ActiveCenterPane = ActiveCenterPane.Transcript);
+        ShowTimelineCenterCommand = new RelayCommand(_ =>
+        {
+            ActiveCenterPane = ActiveCenterPane.Timeline;
+            RightPane.CurrentPane = new TimelinePaneViewModel();
+        });
+        ShowOutlineCenterCommand = new RelayCommand(_ => ActiveCenterPane = ActiveCenterPane.Outline);
+        ShowCharBibleCenterCommand = new RelayCommand(_ => ActiveCenterPane = ActiveCenterPane.CharBible);
+        ShowLocBibleCenterCommand = new RelayCommand(_ => ActiveCenterPane = ActiveCenterPane.LocBible);
+        ShowItemBibleCenterCommand = new RelayCommand(_ => ActiveCenterPane = ActiveCenterPane.ItemBible);
+
+        ToggleRightPaneCommand = new RelayCommand(_ => IsRightPaneVisible = !IsRightPaneVisible);
+        ShowCharactersCommand = new RelayCommand(_ => { RightPane.CurrentPane = new CharacterPaneViewModel(); ActiveRightPane = ActiveRightPane.Character; IsRightPaneVisible = true; });
+        ShowLocationsCommand = new RelayCommand(_ => { RightPane.CurrentPane = new LocationPaneViewModel(); ActiveRightPane = ActiveRightPane.Location; IsRightPaneVisible = true; });
+        ShowItemsCommand = new RelayCommand(_ => { RightPane.CurrentPane = new ItemPaneViewModel(); ActiveRightPane = ActiveRightPane.Item; IsRightPaneVisible = true; });
+        ShowTimelineCommand = new RelayCommand(_ => { RightPane.CurrentPane = new TimelinePaneViewModel(); ActiveRightPane = ActiveRightPane.Character; });
+
+        InsertSceneBreakCommand = new RelayCommand(_ => TranscriptText += "\n***\n");
+
+        ExportPdfCommand = new RelayCommand(_ => StatusMessage = "Export PDF clicked");
+        ExportDocxCommand = new RelayCommand(_ => StatusMessage = "Export DOCX clicked");
+        ExportRtfCommand = new RelayCommand(_ => StatusMessage = "Export RTF clicked");
+        ExportTxtCommand = new RelayCommand(_ => StatusMessage = "Export TXT clicked");
+
+        UpdateCounts();
+    }
+
+    private void UpdateCounts()
+    {
+        var text = TranscriptText ?? string.Empty;
+        CharCount = text.Length;
+        WordCount = text.Split(new[] { ' ', '\n', '\r', '\t' }, StringSplitOptions.RemoveEmptyEntries).Length;
     }
 }


### PR DESCRIPTION
## Summary
- add ribbon-style TopBar with bibles and export groups
- rebuild window into 4-row grid with left nav and toggleable right pane
- track active panes and export commands in view model

## Testing
- `dotnet build` *(fails: .NET 9.0 target requires newer SDK)*

------
https://chatgpt.com/codex/tasks/task_e_68a7802518d48330886018034274d560